### PR TITLE
Feature/#19 diagnosis db models

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@
 erDiagram
     users {
         bigint id PK "ID"
-        int sweetness_type_id "甘さタイプID"
+        int sweetness_type_id FK "甘さタイプID"
         string name "ユーザー名"
         string email "メールアドレス"
         text self_introduction "自己紹介文"
@@ -163,7 +163,7 @@ erDiagram
 
     sweetness_types {
         bigint id PK "ID"
-        string name "甘さタイプ名"
+        int sweetness_kind "甘さタイプの種類"
         datetime created_at "作成日時"
         datetime updated_at "更新日時"
     }
@@ -171,6 +171,7 @@ erDiagram
     sweetness_profiles {
         bigint id PK "ID"
         int user_id FK "ユーザーID"
+        int sweetness_type_id FK "甘さタイプID"
         int sweetness_strength "甘みの強さ"
         int aftertaste_clarity "後味のキレ/スッキリ感"
         int natural_sweetness "自然な甘さ"
@@ -210,12 +211,13 @@ erDiagram
 
     %% === ユーザー関連 ===
     users }o--|| sweetness_types : "多:1"
-    users ||--|| sweetness_profiles : "1:1"
+    users ||--o{ sweetness_profiles : "1:多"
     users ||--o{ posts : "1:多"
     
     %% === ユーザーの実績・評価関連 ===
     users ||--o{ user_badges : "1:多"
     badges ||--o{ user_badges : "1:多"
+    sweetness_types ||--o{ sweetness_profiles : "1:多"
     
     %% === 投稿・評価・カテゴリ関連 ===
     posts ||--|| post_sweetness_scores : "1:1"

--- a/app/models/sweetness_profile.rb
+++ b/app/models/sweetness_profile.rb
@@ -1,0 +1,4 @@
+class SweetnessProfile < ApplicationRecord
+  belongs_to :user
+  belongs_to :sweetness_type
+end

--- a/app/models/sweetness_type.rb
+++ b/app/models/sweetness_type.rb
@@ -1,0 +1,3 @@
+class SweetnessType < ApplicationRecord
+  has_many :users
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  belongs_to :current_sweetness_type, class_name: "SweetnessType", foreign_key: "sweetness_type_id", optional: true
+
   validates :name, presence: true, length: { maximum: 10 }, uniqueness: true
   validates :uid, presence: true, uniqueness: { scope: :provider }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   belongs_to :current_sweetness_type, class_name: "SweetnessType", foreign_key: "sweetness_type_id", optional: true
+  has_many :sweetness_profiles, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 10 }, uniqueness: true
   validates :uid, presence: true, uniqueness: { scope: :provider }

--- a/db/migrate/20250731102049_create_sweetness_types.rb
+++ b/db/migrate/20250731102049_create_sweetness_types.rb
@@ -1,0 +1,9 @@
+class CreateSweetnessTypes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :sweetness_types do |t|
+      t.integer :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250731120531_add_sweetness_type_to_users.rb
+++ b/db/migrate/20250731120531_add_sweetness_type_to_users.rb
@@ -1,0 +1,5 @@
+class AddSweetnessTypeToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :users, :sweetness_type, foreign_key: true
+  end
+end

--- a/db/migrate/20250801001450_create_sweetness_profiles.rb
+++ b/db/migrate/20250801001450_create_sweetness_profiles.rb
@@ -1,0 +1,14 @@
+class CreateSweetnessProfiles < ActiveRecord::Migration[7.2]
+  def change
+    create_table :sweetness_profiles do |t|
+      t.references :user, foreign_key: true
+      t.integer :sweetness_strength
+      t.integer :aftertaste_clarity
+      t.integer :natural_sweetness
+      t.integer :coolness
+      t.integer :richness
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250801003236_add_foreign_keys_to_sweetness_profiles.rb
+++ b/db/migrate/20250801003236_add_foreign_keys_to_sweetness_profiles.rb
@@ -1,0 +1,5 @@
+class AddForeignKeysToSweetnessProfiles < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :sweetness_profiles, :sweetness_type, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20250801122015_rename_name_to_sweetness_kind_in_sweetness_types.rb
+++ b/db/migrate/20250801122015_rename_name_to_sweetness_kind_in_sweetness_types.rb
@@ -1,0 +1,5 @@
+class RenameNameToSweetnessKindInSweetnessTypes < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :sweetness_types, :name, :sweetness_kind
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_31_102049) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_31_120531) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,8 +31,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_31_102049) do
     t.datetime "updated_at", null: false
     t.string "provider"
     t.string "uid"
+    t.bigint "sweetness_type_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["sweetness_type_id"], name: "index_users_on_sweetness_type_id"
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
+
+  add_foreign_key "users", "sweetness_types"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_30_024305) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_31_102049) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "sweetness_types", force: :cascade do |t|
+    t.integer "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_01_003236) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_01_122015) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,7 +29,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_01_003236) do
   end
 
   create_table "sweetness_types", force: :cascade do |t|
-    t.integer "name"
+    t.integer "sweetness_kind"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_31_120531) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_01_001450) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "sweetness_profiles", force: :cascade do |t|
+    t.bigint "user_id"
+    t.integer "sweetness_strength"
+    t.integer "aftertaste_clarity"
+    t.integer "natural_sweetness"
+    t.integer "coolness"
+    t.integer "richness"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_sweetness_profiles_on_user_id"
+  end
 
   create_table "sweetness_types", force: :cascade do |t|
     t.integer "name"
@@ -38,5 +50,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_31_120531) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "sweetness_profiles", "users"
   add_foreign_key "users", "sweetness_types"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_01_001450) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_01_003236) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_01_001450) do
     t.integer "richness"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "sweetness_type_id", null: false
+    t.index ["sweetness_type_id"], name: "index_sweetness_profiles_on_sweetness_type_id"
     t.index ["user_id"], name: "index_sweetness_profiles_on_user_id"
   end
 
@@ -50,6 +52,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_01_001450) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "sweetness_profiles", "sweetness_types"
   add_foreign_key "sweetness_profiles", "users"
   add_foreign_key "users", "sweetness_types"
 end

--- a/test/fixtures/sweetness_profiles.yml
+++ b/test/fixtures/sweetness_profiles.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  sweetness_strength: 1
+  aftertaste_clarity: 1
+  natural_sweetness: 1
+  coolness: 1
+  richness: 1
+
+two:
+  user: two
+  sweetness_strength: 1
+  aftertaste_clarity: 1
+  natural_sweetness: 1
+  coolness: 1
+  richness: 1

--- a/test/fixtures/sweetness_profiles.yml
+++ b/test/fixtures/sweetness_profiles.yml
@@ -2,6 +2,7 @@
 
 one:
   user: one
+  sweetness_type_id: 1
   sweetness_strength: 1
   aftertaste_clarity: 1
   natural_sweetness: 1
@@ -10,6 +11,7 @@ one:
 
 two:
   user: two
+  sweetness_type_id: 1
   sweetness_strength: 1
   aftertaste_clarity: 1
   natural_sweetness: 1

--- a/test/fixtures/sweetness_types.yml
+++ b/test/fixtures/sweetness_types.yml
@@ -1,7 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
+  id: 1
   sweetness_kind: 1
 
 two:
+  id: 2
   sweetness_kind: 1

--- a/test/fixtures/sweetness_types.yml
+++ b/test/fixtures/sweetness_types.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name: 1
+  sweetness_kind: 1
 
 two:
-  name: 1
+  sweetness_kind: 1

--- a/test/fixtures/sweetness_types.yml
+++ b/test/fixtures/sweetness_types.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: 1
+
+two:
+  name: 1

--- a/test/models/sweetness_profile_test.rb
+++ b/test/models/sweetness_profile_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SweetnessProfileTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/sweetness_type_test.rb
+++ b/test/models/sweetness_type_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SweetnessTypeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 実装概要
- SweetnessTypes, SweetnessProfilesテーブルの作成
- Usersテーブルに外部キーを追加
- 各モデルにアソシエーションを定義（user / sweetness_type / sweetness_profile）

## 修正事項
- Usersテーブルに`sweetness_type_id`の外部キーを追加
- SweetnessProfilesテーブルのカラム名を変更（`name` -> `sweetness_kind` ）
  - enumで管理するため integer型 を前提とした命名にした
  - `name`というカラム名だと string型 の意味合いが強いため避けた
  - `badges.badge_kind`との命名規則統一のため
- usersテーブルとsweetness_profilesテーブルのリレーションを「1:1」から「1:多」へ変更
   - ユーザーは複数回診断を行い、将来的にそれぞれの診断結果を保存・参照できるようにするため
  
## 補足
- 未ログインでも診断結果が保存できるよう、モデルのバリデーションは条件付きで制御要
  
close #19