### PR TITLE
Feature/#21 diagnosis result chart

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem "devise-i18n"
 gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"
 
+gem "swimming_fish", "~> 0.2.2"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -335,6 +335,7 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
+    swimming_fish (0.2.2)
     tailwindcss-rails (4.3.0)
       railties (>= 7.0.0)
       tailwindcss-ruby (~> 4.0)
@@ -405,6 +406,7 @@ DEPENDENCIES
   selenium-webdriver
   sprockets-rails
   stimulus-rails
+  swimming_fish (~> 0.2.2)
   tailwindcss-rails
   turbo-rails
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ erDiagram
         bigint id PK "ID"
         int user_id FK "ユーザーID"
         int sweetness_type_id FK "甘さタイプID"
+        string token "診断結果表示用トークン"
         int sweetness_strength "甘みの強さ"
         int aftertaste_clarity "後味のキレ/スッキリ感"
         int natural_sweetness "自然な甘さ"

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -10,8 +10,8 @@
   default: false;
   prefersdark: false;
   color-scheme: "dark";
-  --color-base-100: #F7F5F2;
-  --color-base-200: #EFEAE5;
+  --color-base-100: #FFFFFF;
+  --color-base-200: #F9F9F9;
   --color-base-300: #C9C5C1;
   --color-base-content: oklch(44% 0.011 73.639);
   --color-primary: #F5B6C7;
@@ -45,5 +45,13 @@
 }
 
 .button-primary {
-  @apply px-5 py-4 text-base-100 rounded-full transition duration-200 hover:brightness-96;
+  @apply px-5 py-4 md:px-6 text-base-100 rounded-full transition duration-200 hover:brightness-96;
+}
+
+.button-secondary {
+  @apply px-5 py-4 md:px-6 md:py-5 text-neutral rounded-full transition duration-200 hover:brightness-96;
+}
+
+.button-close {
+  @apply px-5 py-3 md:px-6 text-neutral ring-4 rounded-full transition duration-200 bg-base-100 hover:brightness-96;
 }

--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -7,9 +7,11 @@ class DiagnosesController < ApplicationController
 
   def create
     if unanswered_questions?
-      flash.now[:alert] = "未回答の設問があります。"
       @questions = DIAGNOSIS_QUESTIONS
-      render :new, status: :unprocessable_entity and return
+      @selected_answers = diagnosis_params.to_h
+      flash.now[:modal_alert] = "未回答の設問があります。"
+      render :new, status: :unprocessable_entity
+      return
     end
 
     diagnoser = Diagnosis::SweetnessDiagnoser.new(diagnosis_params)
@@ -31,12 +33,14 @@ class DiagnosesController < ApplicationController
   private
 
   def unanswered_questions?
+    return true if params[:diagnosis].blank?
+
     required_keys = DIAGNOSIS_QUESTIONS.map { |q| q["category"] }
     required_keys.any? { |key| diagnosis_params[key].blank? }
   end
 
   def diagnosis_params
-    params.require(:diagnosis).permit(
+    params.fetch(:diagnosis, {}).permit(
       :sweetness_strength,
       :aftertaste_clarity,
       :natural_sweetness,

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./chart"

--- a/app/javascript/chart.js
+++ b/app/javascript/chart.js
@@ -1,0 +1,2 @@
+import Chart from 'chart.js/auto';
+window.Chart = Chart;

--- a/app/models/sweetness_profile.rb
+++ b/app/models/sweetness_profile.rb
@@ -10,4 +10,17 @@ class SweetnessProfile < ApplicationRecord
       break unless SweetnessProfile.exists?(token: token)
     end
   end
+
+  def sweetness_kind
+    diagnoser = Diagnosis::SweetnessDiagnoser.new(
+      {
+        "sweetness_strength" => sweetness_strength,
+        "aftertaste_clarity" => aftertaste_clarity,
+        "natural_sweetness" => natural_sweetness,
+        "coolness" => coolness,
+        "richness" => richness
+      }
+    )
+    diagnoser.send(:diagnose_kind, diagnoser.call[:scores])
+  end
 end

--- a/app/models/sweetness_profile.rb
+++ b/app/models/sweetness_profile.rb
@@ -1,4 +1,13 @@
 class SweetnessProfile < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :sweetness_type
+
+  before_create :generate_token
+
+  def generate_token
+    loop do
+      self.token = SecureRandom.uuid
+      break unless SweetnessProfile.exists?(token: token)
+    end
+  end
 end

--- a/app/models/sweetness_profile.rb
+++ b/app/models/sweetness_profile.rb
@@ -1,4 +1,4 @@
 class SweetnessProfile < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, optional: true
   belongs_to :sweetness_type
 end

--- a/app/models/sweetness_type.rb
+++ b/app/models/sweetness_type.rb
@@ -1,3 +1,10 @@
 class SweetnessType < ApplicationRecord
   has_many :users
+
+    enum sweetness_kind: {
+    fresh_natural: 0,
+    rich_romantic: 1,
+    sweet_dreamer: 2,
+    balance_seeker: 3
+  }
 end

--- a/app/services/diagnosis/sweetness_diagnoser.rb
+++ b/app/services/diagnosis/sweetness_diagnoser.rb
@@ -5,7 +5,11 @@ module Diagnosis
     end
 
     def call
-      calculate_scores
+      scores = calculate_scores
+      {
+        scores: scores,
+        sweetness_kind: diagnose_kind(scores)
+      }
     end
 
     private
@@ -18,6 +22,19 @@ module Diagnosis
         coolness: @answers["coolness"].to_i,
         richness: @answers["richness"].to_i
       }
+    end
+
+    def diagnose_kind(scores)
+      if scores[:sweetness_strength] >= 4 && scores[:richness] >= 4
+        :rich_romantic
+      elsif scores[:sweetness_strength] == scores.values.max && scores[:sweetness_strength] >= 4
+        :sweet_dreamer
+      elsif (scores[:coolness] == scores.values.max || scores[:natural_sweetness] == scores.values.max) &&
+            (scores[:coolness] >= 4 || scores[:natural_sweetness] >= 4)
+        :fresh_natural
+      else
+        :balance_seeker
+      end
     end
   end
 end

--- a/app/views/diagnoses/new.html.erb
+++ b/app/views/diagnoses/new.html.erb
@@ -34,7 +34,9 @@
             <div class="pt-1">
               <% q["options"].each do |opt| %>
                 <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content ">
-                  <%= f.radio_button q["category"], opt["score"], class: "radio radio-accent radio-sm mt-1 ml-4" %>
+                  <%= f.radio_button q["category"], opt["score"],
+                      checked: (@selected_answers && @selected_answers[q["category"]] == opt["score"].to_s),
+                      class: "radio radio-accent radio-sm mt-1 ml-4" %>
                   <span><%= opt["text"] %></span>
                 </label>
               <% end %>

--- a/app/views/diagnoses/new.html.erb
+++ b/app/views/diagnoses/new.html.erb
@@ -1,57 +1,59 @@
-<div class="flex flex-col items-center justify-center p-1 md:p-4 w-full max-w-3xl mx-auto bg-base-100 rounded-4xl">
-  <h1 class="text-center text-2xl md:text-4xl my-2 md:my-4"><%= t('.title') %></h1>
+<div class="p-2 md:p-4">
+  <div class="flex flex-col p-2 items-center justify-center w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
+    <h1 class="text-center text-2xl md:text-3xl p-4">
+    <%= t('.title') %></h1>
 
-  <%= form_with url: diagnoses_path, method: :post, local: true, scope: :diagnosis do |f| %>
-    <%= render "shared/flash_message" %>
-    
-    <div class="py-4 px-2 md:px-8 md:py-6 w-full max-w-3xl mx-auto">
-      <div class="mb-4 text-center">
-        <% t("diagnoses.new.descriptions").each do |desc| %>
-          <p class="mb-1 text-sm md:text-lg"><%= desc %></p>
-        <% end %>
-      </div>
+    <%= form_with url: diagnoses_path, method: :post, local: true, scope: :diagnosis do |f| %>
+      <%= render "shared/flash_message" %>
 
-      <div class="form-control text-left text-neutral p-1 md:p-2 md:px-30 md:py-6 w-full max-w-3xl mx-auto md:whitespace-nowrap">
-        <% @questions.each_with_index do |q, index| %>
-          <div class="w-full max-w-md mx-auto px-2 py-4 md:p-4 md:max-w-none md:mx-0 border-t border-base-300">
-            
-            <div class="label-text mb-2 md:mb-6 pt-2 md:text-xl">
-              <span class="mr-3">Q<%= index + 1 %>.</span><%= q["question"] %>
-            </div>
-            
-            <% if index == 0 %>
-              <div class="w-full flex justify-center my-3">
-                <%= image_tag "pancake.webp", class: "max-w-[200px] md:max-w-[350px]" %>
+      <div class="py-4 px-2 md:px-8 md:py-6 max-w-3xl mx-auto">
+        <div class="mb-4 text-center">
+          <% t("diagnoses.new.descriptions").each do |desc| %>
+            <p class="mb-1 text-sm md:text-lg"><%= desc %></p>
+          <% end %>
+        </div>
+
+        <div class="form-control text-left text-neutral p-1 md:p-2 md:px-30 md:py-6 w-full max-w-3xl mx-auto md:whitespace-nowrap">
+          <% @questions.each_with_index do |q, index| %>
+            <div class="w-full max-w-md mx-auto px-2 py-4 md:p-4 md:max-w-none md:mx-0">
+              
+              <div class="label-text mb-2 md:mb-6 pt-2 md:text-xl">
+                <span class="mr-3">Q<%= index + 1 %>.</span><%= q["question"] %>
               </div>
-            <% end %>
-
-            <% if index == 3 %>
-              <div class="pb-2 text-center text-sm text-gray-400">
-                <%= t('.example') %>
-              </div>
-            <% end %>
-
-            <div class="pt-1">
-              <% q["options"].each do |opt| %>
-                <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content ">
-                  <%= f.radio_button q["category"], opt["score"],
-                      checked: (@selected_answers && @selected_answers[q["category"]] == opt["score"].to_s),
-                      class: "radio radio-accent radio-sm mt-1 ml-4" %>
-                  <span><%= opt["text"] %></span>
-                </label>
+              
+              <% if index == 0 %>
+                <div class="w-full flex justify-center my-3">
+                  <%= image_tag "pancake.webp", class: "max-w-[200px] md:max-w-[350px]" %>
+                </div>
               <% end %>
-            </div>
-          </div>
-        <% end %>
 
-        <div class="text-center mt-4 md:mt-8 pb-2 md:pb-0">
-          <%= f.submit "診断する", class: "bg-accent button-primary" %>
+              <% if index == 3 %>
+                <div class="pb-2 text-center text-sm text-gray-400">
+                  <%= t('.example') %>
+                </div>
+              <% end %>
+
+              <div class="pt-1">
+                <% q["options"].each do |opt| %>
+                  <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content ">
+                    <%= f.radio_button q["category"], opt["score"],
+                        checked: (@selected_answers && @selected_answers[q["category"]] == opt["score"].to_s),
+                        class: "radio radio-accent radio-sm mt-1 ml-4" %>
+                    <span><%= opt["text"] %></span>
+                  </label>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+
+          <div class="text-center mt-4 md:mt-8 pb-2 md:pb-0">
+            <%= f.submit "診断する", class: "bg-accent button-primary" %>
+          </div>
         </div>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>
-
 
 
 

--- a/app/views/diagnoses/show.html.erb
+++ b/app/views/diagnoses/show.html.erb
@@ -1,7 +1,7 @@
 <div class="p-2 md:p-4"> 
   <div class="p-2 rounded-3xl w-full max-w-3xl mx-auto bg-base-200">
     <div class="text-xl md:text-3xl text-neutral text-center p-4">
-      結果発表
+      <%= t('.title') %>
     </div>
     <div class="text-base md:text-xl border-t border-base-300 leading-relaxed text-neutral text-center p-6">
       あなたの<span class="sm:hidden"><br></span>「好みの甘さ感覚チャート」が<br>出来上がりました！

--- a/app/views/diagnoses/show.html.erb
+++ b/app/views/diagnoses/show.html.erb
@@ -1,10 +1,40 @@
-<h1>診断結果</h1>
-<p>あなたのタイプは：<%= t("enums.sweetness_type.sweetness_kind.#{@profile.sweetness_type_name}") %></p>
+<div class="p-2 md:p-4"> 
+  <div class="p-2 rounded-3xl w-full max-w-3xl mx-auto bg-base-200">
+    <div class="text-xl md:text-3xl text-neutral text-center p-4">
+      結果発表
+    </div>
+    <div class="text-base md:text-xl border-t border-base-300 leading-relaxed text-neutral text-center p-6">
+      あなたの<span class="sm:hidden"><br></span>「好みの甘さ感覚チャート」が<br>出来上がりました！
+    </div>
+    <div class="px-10 py-4 md:py-6 text-neutral">
+      <div class="flex justify-center items-end flex-wrap gap-1 md:gap-2 text-base">
+        <span class="text-left self-start">あなたは...</span>
+        <span class="text-xl md:text-2xl bg-primary text-center rounded-3xl px-5 py-3 md:px-6 md:py-4 text-base-100">
+          <%= I18n.t("enums.sweetness_type.sweetness_kind.#{@profile.sweetness_kind}") %>
+        </span>
+        <span class="text-base text-neutral ml-auto md:ml-0">タイプです</span>
+      </div>
+    </div>
 
-<ul>
-  <li>甘さの強さ：<%= @profile.sweetness_strength %></li>
-  <li>後味のキレ：<%= @profile.aftertaste_clarity %></li>
-  <li>自然な甘さ：<%= @profile.natural_sweetness %></li>
-  <li>爽快感：<%= @profile.coolness %></li>
-  <li>甘さの深み：<%= @profile.richness %></li>
-</ul>
+    <div class="flex justify-center p-4">
+        <div class="w-full max-w-md">
+        <div class="p-4 border-secondary rounded-3xl bg-base-100">
+            <%= render "shared/chart",
+            chart_id: "radarChart",
+            data: [
+                @profile.sweetness_strength,
+                @profile.aftertaste_clarity,
+                @profile.natural_sweetness,
+                @profile.coolness,
+                @profile.richness,
+            ] %>
+        </div>
+        </div>
+    </div>
+
+    <div class="flex flex-col items-center gap-6 p-8">
+      <%= link_to "X で結果をシェアする", "#", class: "bg-accent button-secondary" %>
+      <%= link_to "閉じる", "#", data: { turbo: false }, class: "bg-accent ring-accent button-close" %>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
 
   <body class="min-h-screen flex flex-col bg-center bg-no-repeat bg-fixed bg-cover font-kiwi">
     <%= render 'shared/header' %>
-    <main class="container flex-1 pt-4 pb-14 md:pb-20 px-4 mx-auto">
+    <main class="container flex-1 pt-20 pb-14 md:pb-20 px-4 mx-auto">
       <% if notice.present? %>
         <%= render 'shared/notice', notice: notice %>
       <% end %>

--- a/app/views/shared/_chart.html.erb
+++ b/app/views/shared/_chart.html.erb
@@ -1,0 +1,40 @@
+<canvas id="radarChart" width="400" height="400"></canvas>
+
+<script>
+  document.addEventListener("turbo:load", function () {
+    const ctx = document.getElementById("radarChart");
+    if (!ctx) return;
+
+    if (Chart.getChart(ctx)) {
+      Chart.getChart(ctx).destroy();
+    }
+      // 画面幅でborderWidthを切り替え
+    const borderWidth = window.innerWidth < 768 ? 2 : 4;
+    new Chart(ctx, {
+      type: 'radar',
+      data: {
+        labels: ["甘みの強さ", ["後味のキレ/","スッキリ感"], "自然な甘さ", "爽快感", "甘さの深み/コク"],
+        datasets: [{
+          label: "好みの甘さ感覚",
+          data: [<%= data.map(&:to_i).join(", ") %>],
+          backgroundColor: 'rgba(245, 182, 199, 0.4)',
+          borderColor: 'rgba(245, 182, 199, 0.6)',
+          borderWidth: borderWidth,
+          pointBackgroundColor: 'rgba(245, 182, 199, 0.6)'
+        }]
+      },
+      options: {
+        responsive: true,
+        scales: {
+          r: {
+            min: 0,
+            max: 5,
+            ticks: {
+              stepSize: 1
+            }
+          }
+        }
+      }
+    });
+  });
+</script>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <div class="navbar bg-base-100 text-neutral shadow-sm px-2 md:px-4 py-2 sticky top-0 z-50">
+  <div class="fixed top-0 navbar bg-base-200 text-neutral shadow-sm px-2 md:px-4 py-2 z-50">
     
     <!-- ロゴ -->
     <div class="navbar-start">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,7 +15,7 @@ ja:
               too_short: "は%{count}文字以上で入力してください"
               password_confirmation: "パスワードが間違っています"
   errors:
-    format: "%{attribute} %{message}"
+    format: "・%{attribute} %{message}"
     messages:
       blank: を入力してください
       too_long: は%{count}文字以内で入力してください
@@ -29,8 +29,12 @@ ja:
         - あなたの好みの甘さ感覚を診断します。
         - ※ 全部で5問あります
       example:  例 ) ミントチョコ、清涼系ガム
+    show:
+      title: 診断結果
   enums:
     sweetness_type:
       sweetness_kind:
-        natural_taster: "さっぱり自然派"
-        richness_roman: "濃厚ロマン派"
+        fresh_natural: "さっぱり自然派"
+        rich_romantic: "濃厚ロマン派"
+        sweet_dreamer: "甘党ドリーマー"
+        balance_seeker: "バランス探求派"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,8 @@ Rails.application.routes.draw do
 
   root "static_pages#top"
 
-  resources :diagnoses, only: [:new, :create]
-  get 'diagnoses/result/:token', to: 'diagnoses#show', as: :diagnosis_result
+  resources :diagnoses, only: [ :new, :create ]
+  get "diagnoses/result/:token", to: "diagnoses#show", as: :diagnosis_result
 
   get "up" => "rails/health#show", as: :rails_health_check
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,8 @@ Rails.application.routes.draw do
 
   root "static_pages#top"
 
-  get "diagnoses/new"
-  resources :diagnoses, only: [ :new, :create ]
+  resources :diagnoses, only: [:new, :create]
+  get 'diagnoses/result/:token', to: 'diagnoses#show', as: :diagnosis_result
 
   get "up" => "rails/health#show", as: :rails_health_check
 

--- a/db/migrate/20250805143137_change_column_null_on_sweetness_profiles.rb
+++ b/db/migrate/20250805143137_change_column_null_on_sweetness_profiles.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNullOnSweetnessProfiles < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :sweetness_profiles, :user_id, true
+  end
+end

--- a/db/migrate/20250806040915_add_token_to_sweetness_profiles.rb
+++ b/db/migrate/20250806040915_add_token_to_sweetness_profiles.rb
@@ -1,0 +1,13 @@
+class AddTokenToSweetnessProfiles < ActiveRecord::Migration[7.2]
+  def change
+    add_column :sweetness_profiles, :token, :string
+    add_index :sweetness_profiles, :token, unique: true
+
+    SweetnessProfile.reset_column_information
+    SweetnessProfile.find_each do |profile|
+      profile.update!(token: SecureRandom.uuid)
+    end
+
+    change_column_null :sweetness_profiles, :token, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_01_122015) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_05_143137) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_05_143137) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_06_040915) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,7 +24,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_05_143137) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "sweetness_type_id", null: false
+    t.string "token", null: false
     t.index ["sweetness_type_id"], name: "index_sweetness_profiles_on_sweetness_type_id"
+    t.index ["token"], name: "index_sweetness_profiles_on_token", unique: true
     t.index ["user_id"], name: "index_sweetness_profiles_on_user_id"
   end
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.16",
+    "chart.js": "^4.5.0",
     "daisyui": "^5.0.47"
   }
 }

--- a/test/controllers/diagnoses_controller_test.rb
+++ b/test/controllers/diagnoses_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class DiagnosesControllerTest < ActionDispatch::IntegrationTest
   test "should get new" do
-    get diagnoses_new_url
+    get new_diagnosis_path
     assert_response :success
   end
 end

--- a/test/fixtures/sweetness_profiles.yml
+++ b/test/fixtures/sweetness_profiles.yml
@@ -2,6 +2,7 @@
 
 one:
   user: one
+  token: "1a2b3c4d-5e6f-7g8h-9i0j-k1l2m3n4o5p6"
   sweetness_type_id: 1
   sweetness_strength: 1
   aftertaste_clarity: 1
@@ -11,6 +12,7 @@ one:
 
 two:
   user: two
+  token: "7h8i9j0k-1l2m-3n4o-5p6q-7r8s9t0u1v2w"
   sweetness_type_id: 1
   sweetness_strength: 1
   aftertaste_clarity: 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,10 +150,22 @@
   resolved "https://registry.npmjs.org/@hotwired/turbo/-/turbo-8.0.13.tgz"
   integrity sha512-M7qXUqcGab6G5PKOiwhgbByTtrPgKPFCTMNQ52QhzUEXEqmp0/ApEguUesh/FPiUjrmFec+3lq98KsWnYY2C7g==
 
+"@kurkle/color@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
+  integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
+
 "@rails/actioncable@>=7.0":
   version "8.0.200"
   resolved "https://registry.npmjs.org/@rails/actioncable/-/actioncable-8.0.200.tgz"
   integrity sha512-EDqWyxck22BHmv1e+mD8Kl6GmtNkhEPdRfGFT7kvsv1yoXd9iYrqHDVAaR8bKmU/syC5eEZ2I5aWWxtB73ukMw==
+
+chart.js@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.5.0.tgz#11a1ef6c4befc514b1b0b613ebac226c4ad2740b"
+  integrity sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
 
 daisyui@^5.0.47:
   version "5.0.47"


### PR DESCRIPTION
### 概要
- 診断機能・結果画面を実装
- スコアに応じてタイプを判定
- Chart.jsを導入し、診断結果をレーダーチャートで描画
- enum（sweetness_kind）の追加とi18nの対応

## 主な変更点
- SweetnessProfileモデル
  - tokenカラムを追加（ 診断結果の表示＆シェア用 ）
  - user_idカラムをnull許容に変更（未ログインでも診断できるように ） 
- ヘッダーの固定
- デバッグGem（swimming_fish）の追加

## 動作確認
- [x] 診断後、token付きURLで結果ページに遷移すること
- [x] dbに診断結果が保存されること
- [x] レーダーチャートがスマホ・PCで適切に表示されること

## 補足
- タイプ名・スコアロジックは今後変更あり

close #21