### PR TITLE
Feature/#27 post edit delete

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -60,3 +60,7 @@
 .button-close {
   @apply px-5 py-3 md:px-6 text-neutral ring-4 rounded-full transition duration-200 bg-base-100 hover:brightness-96;
 }
+
+.action-button {
+@apply text-sm px-4 py-2 text-neutral ring-4 rounded-full transition duration-200 bg-base-100 hover:brightness-96;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -13,16 +13,36 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.build(post_params)
     if @post.save
-      flash[:notice] = "投稿しました！"
-      redirect_to posts_path
+      redirect_to posts_path, notice: t("defaults.flash_message.created", item: Post.model_name.human)
     else
-      flash.now[:alert] = "投稿を作成できませんでした"
+      flash.now[:alert] = t("defaults.flash_message.not_created", item: Post.model_name.human)
       render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @post = current_user.posts.find(params[:id])
+  end
+
+  def update
+    @post = current_user.posts.find(params[:id])
+    if @post.update(post_params)
+      redirect_to post_path(@post), notice: t("defaults.flash_message.updated", item: Post.model_name.human)
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_updated", item: Post.model_name.human)
+      render :edit, status: :unprocessable_entity
     end
   end
 
   def show
     @post = Post.find(params[:id])
+  end
+
+  def destroy
+    @post = Post.find(params[:id])
+    @post.image.purge if @post.image.attached?
+    @post.destroy!
+    redirect_to posts_path, notice: t("defaults.flash_message.deleted", item: Post.model_name.human)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,4 +22,8 @@ class User < ApplicationRecord
   def self.create_unique_string
     SecureRandom.uuid
   end
+
+  def own?(object)
+    id == object&.user_id
+  end
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -30,6 +30,16 @@
 
     <div class="form-control">
       <%= f.label :product_image, t("posts.new.product_image"), class: "label md:p-2 text-neutral" %>
+
+      <% if @post.image.attached? %>
+        <div class="flex justify-center">
+          <%= image_tag @post.post_image, class: "w-50 h-50 object-cover rounded-xl" %>
+        </div>
+        <p class="text-sm text-neutral mb-2 text-center leading-relaxed">
+          投稿されている画像は上記です。<br>（変更する場合は下から選択してください）
+        </p>
+      <% end %>
+
       <%= f.file_field :image,
           class: "block w-76 mx-auto text-sm text-base-300
                   file:mr-4 file:py-2 file:px-4 bg-base-100 rounded-xl 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,6 +1,6 @@
 <div class="w-full p-3">
   <!-- カードの高さ指定 -->
-  <div class="card card-side bg-base-200 p-4 shadow-sm h-48 min-h-48 rounded-xl">
+  <div class="card card-side bg-base-200 p-4 shadow-sm h-52 min-h-52 rounded-xl">
     <figure class="flex-shrink-0">
       <!-- 画像 -->
       <div class="w-40 h-40 flex-shrink-0 overflow-hidden rounded-2xl">
@@ -53,11 +53,23 @@
           "too_sweet" => "bg-secondary"
         } %>
 
-        <div class="inline-flex items-center rounded-2xl p-2 gap-2 py-2 px-4 text-neutral text-sm <%= bg_colors[post.sweetness_rating] %>">
+        <div class="inline-flex items-center rounded-2xl p-2 gap-2 py-3 px-4 text-neutral text-base <%= bg_colors[post.sweetness_rating] %>">
           <%= image_tag rating_images[post.sweetness_rating], class: "h-8 w-8" %>
           <p><%= I18n.t("enums.post.sweetness_rating.#{post.sweetness_rating}") %></p>
         </div>
       </div>
     </div>
+
+    <!-- 編集・削除ボタン -->
+    <% if user_signed_in? && current_user.own?(post) %>
+      <div class="absolute bottom-4 right-4 px-2 flex space-x-2 gap-2">
+        <%= link_to edit_post_path(post), class: "ring-accent action-button", data: { turbo: false } do %>
+          編集
+        <% end %>
+        <%= link_to post_path(post), class: "ring-secondary action-button", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+          削除
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,7 @@
+<div class="p-2 md:p-4">
+  <div class="flex flex-col p-2 md:p-6 items-center justify-center w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
+    <h1 class="text-center text-xl md:text-2xl p-4 border-b border-gray-300 w-full">
+      <%= t('.title') %></h1>
+   <%= render 'form', post: @post %>
+  </div>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -48,10 +48,22 @@
             <%= image_tag rating_images[@post.sweetness_rating], class: "h-8 w-8" %>
             <p><%= I18n.t("enums.post.sweetness_rating.#{@post.sweetness_rating}") %></p>
           </div>
+
+          <!-- 編集・削除ボタン -->
+          <% if user_signed_in? && current_user.own?(@post) %>
+            <div class="flex gap-4 pt-4">
+              <%= link_to edit_post_path(@post), class: "text-sm ring-accent px-4 py-2 text-neutral ring-4 rounded-full transition duration-200 bg-base-100 hover:brightness-96", data: { turbo: false } do %>
+                編集
+              <% end %>
+              <%= link_to post_path(@post), class: "text-sm ring-secondary px-4 py-2 text-neutral ring-4 rounded-full transition duration-200 bg-base-100 hover:brightness-96", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+                削除
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>
-     
+  
     <!-- チャート -->
     <div class="flex justify-center p-2">
       <div class="w-full max-w-lg sm:max-w-xl lg:max-w-xl p-2 border-secondary rounded-3xl bg-base-100">
@@ -79,11 +91,14 @@
           <div class="w-full p-6 border-b border-gray-300 text-neutral">
             <% if @post.review.present? %>
               <%= @post.review %>
+              <div class="pt-2 text-sm text-base-300 text-right">
+                <%= l @post.created_at %>
+              </div>
             <% else %>
               <div class="mb-3 text-base-300">レビューがありません</div>
             <% end %>
           </div>
-          <div class="flex flex-row p-2 text-sm gap-6 md:gap-30 text-base-300">
+          <div class="flex flex-row pt-2 text-sm gap-6 md:gap-30 text-base-300">
             <span class="flex items-center gap-1">
               <%= image_tag "chat.svg", class: "h-6 w-6" %>
               コメントする

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,12 @@
 ja:
+  defaults:
+    delete_confirm: "削除しますか？"
+    flash_message:
+      created: "%{item}を作成しました"
+      not_created: "%{item}を作成出来ませんでした"
+      updated: "%{item}を更新しました"
+      not_updated: "%{item}を更新出来ませんでした"
+      deleted: "%{item}を削除しました"
   diagnoses:
     new:
       title: 甘さ感覚診断
@@ -18,6 +26,8 @@ ja:
       post_sweetness_score: あまさ評価
       review: レビュー
       product_image: 商品の画像
+    edit:
+      title: あまピタ評価の編集
     manufacturers:
       list:
         - 明治

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   resources :diagnoses, only: [ :new, :create ]
   get "diagnoses/result/:token", to: "diagnoses#show", as: :diagnosis_result
 
-  resources :posts, only: [ :index, :new, :create, :show ]
+  resources :posts, only: [ :index, :new, :create, :edit, :show, :update, :destroy ]
 
   get "up" => "rails/health#show", as: :rails_health_check
 


### PR DESCRIPTION
## 実装概要
投稿の編集・削除を実装し、フラッシュメッセージを追加しました。

## 主な変更点

### 📋 投稿編集・削除機能
- PostsControllerの`edit`,`update`,`destroy`アクションを実装
- 投稿一覧・詳細画面からの編集・削除操作に対応
- フラッシュメッセージの表示実装
- 編集・削除ボタンの共通スタイルをassetsに集約

## 動作確認
- [x] 画像差し替え時に旧画像がS3から削除されることを確認
- [x] 投稿削除時に関連付け画像もDB・S3から削除されることを確認
- [x] フラッシュメッセージが適切に表示されることを確認
- [x] 画面遷移と編集画面の表示確認

## 技術的な考慮事項
- `purge`メソッドでDB関連付けとストレージファイルを削除

## 今後の改善予定
- [ ] レスポンシブ対応（一覧画面）

close #27