### PR TITLE
Fix/#97 edit form bug

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -141,7 +141,8 @@
     </div>
 
     <div class="form-control p-6">
-      <%= f.submit "投稿する", class: "bg-primary button-primary" %>
+      <%= f.submit f.object.new_record? ? "投稿する" : "更新する",
+            class: "bg-primary button-primary" %>
     </div>
   <% end %>
 </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -59,17 +59,17 @@
     <div class="form-control">
       <%= f.label :manufacturer, t("posts.new.manufacturer"), class: "label p-1 md:p-2 text-neutral" %>
       <%= f.select :manufacturer,
-              options_for_select(I18n.t("posts.manufacturers.list")),
-              { prompt: "メーカーを選択" },
-              class: "select select-bordered w-full" %>
+            options_for_select(I18n.t("posts.manufacturers.list"), @post.manufacturer),
+            { prompt: "メーカーを選択" },
+            class: "select select-bordered w-full" %>
     </div>
 
     <div class="form-control">
       <%= f.label :category_id, t('posts.new.category_id'), class: "label p-1 md:p-2 text-neutral" %>
       <%= f.select :category_id,
-              options_from_collection_for_select(Category.all, :id, :name),
-              { prompt: "カテゴリを選択" },
-              class: "select select-bordered w-full" %>
+            options_from_collection_for_select(Category.all, :id, :name, @post.category_id),
+            { prompt: "カテゴリを選択" },
+            class: "select select-bordered w-full" %>
     </div>
 
     <div class="form-control">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -75,28 +75,46 @@
     <div class="form-control">
       <%= f.label :sweetness_rating, t('posts.new.sweetness_rating'), class: "label p-2 md:p-4 text-neutral" %>
 
-      <div class="flex flex-wrap justify-center gap-4 bg-base-100 p-2 md:p-4 rounded-4xl ring-2 ring-[var(--color-base-400)]">
-        <% ratings = Post.sweetness_ratings.keys.map.with_index do |key, idx| 
-            {
-              value: key, 
-              label: t("enums.post.sweetness_rating.#{key}"),
-              img: [
-                "smiley-meh.svg",
-                "smiley-blank.svg",
-                "smiley-wink.svg",
-                "smiley-nervous.svg",
-                "smiley-x-eyes.svg"
-              ][idx]
-            }
-          end %>
+      <div class="flex flex-wrap justify-center gap-4 bg-base-100 p-2 md:p-6 rounded-4xl ring-2 ring-[var(--color-base-400)]">
+        <% 
+          rating_images = {
+            "lack_of_sweetness" => "smiley-meh.svg",
+            "could_be_sweeter" => "smiley-blank.svg",
+            "perfect_sweetness" => "smiley-wink.svg",
+            "slightly_too_sweet" => "smiley-nervous.svg",
+            "too_sweet" => "smiley-x-eyes.svg"
+          }
 
-        <% ratings.each do |r| %>
-          <label class="flex flex-col items-center space-y-1 basis-1/3 sm:basis-auto cursor-pointer">
-            <%= f.radio_button :sweetness_rating, r[:value], class: "hidden peer" %>
-            <span class="p-2 rounded-full transition-colors md:hover:bg-primary peer-checked:bg-primary">
-              <%= image_tag r[:img], class: "icon-size" %>
+          hover_colors = {
+            "lack_of_sweetness" => "hover:bg-accent",
+            "could_be_sweeter" => "hover:bg-accent", 
+            "perfect_sweetness" => "hover:bg-primary",
+            "slightly_too_sweet" => "hover:bg-secondary",
+            "too_sweet" => "hover:bg-secondary"
+          }
+
+          selected_colors = {
+            "lack_of_sweetness" => "peer-checked:bg-accent",
+            "could_be_sweeter" => "peer-checked:bg-accent",
+            "perfect_sweetness" => "peer-checked:bg-primary", 
+            "slightly_too_sweet" => "peer-checked:bg-secondary",
+            "too_sweet" => "peer-checked:bg-secondary"
+          }
+        %>
+
+        <% Post.sweetness_ratings.keys.each do |rating_key| %>
+          <label class="flex flex-col items-center space-y-1 basis-1/3 sm:basis-auto cursor-pointer sweetness-rating-option" 
+                data-value="<%= rating_key %>">
+            <%= f.radio_button :sweetness_rating, rating_key, 
+                class: "hidden peer sweetness-radio", 
+                data: { turbo_permanent: true } %>
+            <span class="rating-indicator p-2 rounded-full transition-all duration-200 peer-checked:scale-110
+                        <%= hover_colors[rating_key] %> <%= selected_colors[rating_key] %>">
+              <%= image_tag rating_images[rating_key], class: "icon-size pointer-events-none" %>
             </span>
-            <div class="text-sm text-center whitespace-pre-line"><%= r[:label] %></div>
+            <div class="text-sm text-center whitespace-pre-line pointer-events-none">
+              <%= t("enums.post.sweetness_rating.#{rating_key}") %>
+            </div>
           </label>
         <% end %>
       </div>


### PR DESCRIPTION
## 実装概要
パーシャル画面での下記不具合を修正しました。
1. 編集時、投稿時に選択したメーカー名・カテゴリ名がフォームに反映されない問題
2. 投稿時、フラッシュメッセージ後に甘さ評価の画像が選択できない問題

## 📋 主な変更点
- `app/views/posts/_form.html.erb` の `f.select` に選択済みの値を渡すよう修正
 -  CSSクラスの適用順序を最適化し、確実に選択状態が反映されるよう修正

## 🔧 修正理由
1. 従来の実装では `options_for_select` / `options_from_collection_for_select` に選択済み値が渡されていなかったため、編集時に初期選択がされずユーザーが再選択する必要があった。

2. DOM要素の再描画やTurboによる部分更新時に、既存のCSSクラス構造では選択状態が正常に反映されないケースがあった。

## 🎨 UI/UX改善
- 送信ボタンの文言をnew /edit で切り替え
- 甘さ評価画像の選択した際、評価によって色が変わるように調整

## ✅ 動作確認
- 編集時、投稿時に選択したメーカー名とカテゴリ名が初期表示されることを確認
- フラッシュメッセージ表示後も選択できることを確認

close #97