### PR TITLE
fix: Turbo環境下でラジオボタン選択時のpeer-checkedスタイルが崩れる不具合を修正

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,6 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import "./chart"
+import "./ensure_peer_checked"
+import "./force_peer_checked"
+import "./sweetness_radio_highlight"

--- a/app/javascript/ensure_peer_checked.js
+++ b/app/javascript/ensure_peer_checked.js
@@ -1,0 +1,8 @@
+document.addEventListener("turbo:render", () => {
+  // .sweetness-radioクラスが付いた、選択状態（checked）のラジオボタンをすべて取得
+  document.querySelectorAll('input[type="radio"].sweetness-radio:checked').forEach((el) => {
+    // それぞれのラジオボタンに対して、changeイベントを強制的に発火させる
+    // これによって、Tailwind CSSのpeer-checkedなどのスタイルが正しく再適用される
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+});

--- a/app/javascript/force_peer_checked.js
+++ b/app/javascript/force_peer_checked.js
@@ -1,0 +1,13 @@
+document.addEventListener("turbo:load", () => {
+  // .sweetness-radioクラスが付いた全てのラジオボタンを取得して、1つずつ処理する
+  document.querySelectorAll('input[type="radio"].sweetness-radio').forEach((el) => {
+    // それぞれのラジオボタンに「change」イベント（値が変わったときに発火）を設定する
+    el.addEventListener('change', (e) => {
+      // 同じname属性を持つ（＝同じグループの）ラジオボタンをすべて取得し、1つずつ処理する
+      document.querySelectorAll(`input[name="${el.name}"]`).forEach((peer) => {
+        // そのラジオボタンに「input」イベントを強制的に発火させる
+        peer.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+    });
+  });
+});

--- a/app/javascript/sweetness_radio_highlight.js
+++ b/app/javascript/sweetness_radio_highlight.js
@@ -1,0 +1,29 @@
+document.addEventListener("turbo:load", () => {
+  // すべてのラジオボタン（.sweetness-radio）を取得
+  document.querySelectorAll('.sweetness-radio').forEach((radio) => {
+    // それぞれのラジオボタンに「選択されたとき」の動きを追加
+    radio.addEventListener('change', () => {
+      const name = radio.name;
+      // // 同じグループの全ラジオボタンについて…
+      document.querySelectorAll(`input[name="${name}"]`).forEach((el) => {
+        // それぞれのラジオボタンを囲む<label>の中の.rating-indicatorから色を消す
+        el.closest('label').querySelector('.rating-indicator').classList.remove(
+          'bg-accent', 'bg-primary', 'bg-secondary'
+        );
+      });
+      // 選択されたラジオボタンの.rating-indicatorだけに色を付ける
+      // closest('label')で、ラジオボタンを囲む一番近い<label>要素を取得する
+      const indicator = radio.closest('label').querySelector('.rating-indicator');
+      if (radio.checked) {
+        // rating_keyごとに色を切り替え
+        if (radio.value === "lack_of_sweetness" || radio.value === "could_be_sweeter") {
+          indicator.classList.add('bg-accent');
+        } else if (radio.value === "perfect_sweetness") {
+          indicator.classList.add('bg-primary');
+        } else if (radio.value === "slightly_too_sweet" || radio.value === "too_sweet") {
+          indicator.classList.add('bg-secondary');
+        }
+      }
+    });
+  });
+});

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -107,9 +107,9 @@
                 data-value="<%= rating_key %>">
             <%= f.radio_button :sweetness_rating, rating_key, 
                 class: "hidden peer sweetness-radio", 
-                data: { turbo_permanent: true } %>
-            <span class="rating-indicator p-2 rounded-full transition-all duration-200 peer-checked:scale-110
-                        <%= hover_colors[rating_key] %> <%= selected_colors[rating_key] %>">
+                data: { turbo_permanent: true },
+                checked: (f.object.sweetness_rating == rating_key) %>
+            <span class="rating-indicator p-2 rounded-full transition-all duration-200 <%= hover_colors[rating_key] %> ">
               <%= image_tag rating_images[rating_key], class: "icon-size pointer-events-none" %>
             </span>
             <div class="text-sm text-center whitespace-pre-line pointer-events-none">


### PR DESCRIPTION
## 実装概要
- Turbo（Hotwire）とTailwind CSSの組み合わせ環境で、ラジオボタン選択時のpeer-checkedスタイル（色）がバリデーションエラー後に正しく反映されない不具合を修正しました。
- JavaScriptによる補助（`ensure_peer_checked.js`、`force_peer_checked.js`、`sweetness_radio_highlight.js`）を追加し、選択状態や見た目が常に正しく反映されるようにしました。

## 📋 主な変更点
- ラジオボタン選択時の色が崩れないよう、JSで状態を補助
- Turboによる部分描画後も、選択状態・スタイルが維持されるように修正

## 🔧 修正理由
甘さ評価未選択時にフラッシュメッセージが表示された後、画像をクリックしても値は保持されているが、選択状態の色が反映されない問題が発生していたため。

## 🔧 なぜ発生していたか
- Turboはフォームの一部だけを差し替えるため、Tailwindのpeer-checkedによるスタイルが再適用されないことがある
- 「未選択→バリデーションエラー→再選択」の流れで、CSSだけでは状態管理が難しい

## 🎨 UI/UX改善
ページリロードやTurbo無効化（`data: { turbo: false }`）ではUXが低下するため、JavaScriptで補助して不具合を修正

## ✅ 動作確認
- [x] ラジオボタンを選択→色が正しく反映されること
- [x] 未選択で投稿→バリデーションエラー後に再選択しても見た目が崩れないこと
- [x] Turboを有効にしたまま、UXを損なわずに動作すること

close #99