### PR TITLE
fix:編集画面で投稿時のラジオボタンに色が保持されていない不具合を修正

### DIFF
--- a/app/javascript/sweetness_radio_highlight.js
+++ b/app/javascript/sweetness_radio_highlight.js
@@ -1,29 +1,40 @@
-document.addEventListener("turbo:load", () => {
-  // すべてのラジオボタン（.sweetness-radio）を取得
+function updateSweetnessRadioHighlight() {
+  // すべての色をリセット
   document.querySelectorAll('.sweetness-radio').forEach((radio) => {
-    // それぞれのラジオボタンに「選択されたとき」の動きを追加
-    radio.addEventListener('change', () => {
-      const name = radio.name;
-      // // 同じグループの全ラジオボタンについて…
-      document.querySelectorAll(`input[name="${name}"]`).forEach((el) => {
-        // それぞれのラジオボタンを囲む<label>の中の.rating-indicatorから色を消す
-        el.closest('label').querySelector('.rating-indicator').classList.remove(
-          'bg-accent', 'bg-primary', 'bg-secondary'
-        );
-      });
-      // 選択されたラジオボタンの.rating-indicatorだけに色を付ける
-      // closest('label')で、ラジオボタンを囲む一番近い<label>要素を取得する
-      const indicator = radio.closest('label').querySelector('.rating-indicator');
-      if (radio.checked) {
-        // rating_keyごとに色を切り替え
-        if (radio.value === "lack_of_sweetness" || radio.value === "could_be_sweeter") {
-          indicator.classList.add('bg-accent');
-        } else if (radio.value === "perfect_sweetness") {
-          indicator.classList.add('bg-primary');
-        } else if (radio.value === "slightly_too_sweet" || radio.value === "too_sweet") {
-          indicator.classList.add('bg-secondary');
-        }
-      }
-    });
+    radio.closest('label').querySelector('.rating-indicator').classList.remove(
+      'bg-accent', 'bg-primary', 'bg-secondary'
+    );
   });
-});
+  // checkedのものだけ色を付ける
+  document.querySelectorAll('input[type="radio"].sweetness-radio:checked').forEach((radio) => {
+    const indicator = radio.closest('label').querySelector('.rating-indicator');
+    if (radio.value === "lack_of_sweetness" || radio.value === "could_be_sweeter") {
+      indicator.classList.add('bg-accent');
+    } else if (radio.value === "perfect_sweetness") {
+      indicator.classList.add('bg-primary');
+    } else if (radio.value === "slightly_too_sweet" || radio.value === "too_sweet") {
+      indicator.classList.add('bg-secondary');
+    }
+  });
+}
+
+// Turboの描画イベントごとにイベント登録と初期化をやり直す
+function setupSweetnessRadioHighlight() {
+  // まず全てのイベントリスナーを解除（同じイベントが重複しないように）
+  document.querySelectorAll('.sweetness-radio').forEach((radio) => {
+    radio.replaceWith(radio.cloneNode(true));
+  });
+
+  // 再度イベント登録
+  document.querySelectorAll('.sweetness-radio').forEach((radio) => {
+    radio.addEventListener('change', updateSweetnessRadioHighlight);
+    radio.addEventListener('input', updateSweetnessRadioHighlight);
+  });
+
+  // 初期状態の色付け
+  updateSweetnessRadioHighlight();
+}
+
+// Turboの描画イベントで毎回セットアップ
+document.addEventListener("turbo:load", setupSweetnessRadioHighlight);
+document.addEventListener("turbo:render", setupSweetnessRadioHighlight);

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -105,10 +105,9 @@
         <% Post.sweetness_ratings.keys.each do |rating_key| %>
           <label class="flex flex-col items-center space-y-1 basis-1/3 sm:basis-auto cursor-pointer sweetness-rating-option" 
                 data-value="<%= rating_key %>">
-            <%= f.radio_button :sweetness_rating, rating_key, 
-                class: "hidden peer sweetness-radio", 
-                data: { turbo_permanent: true },
-                checked: (f.object.sweetness_rating == rating_key) %>
+           <%= f.radio_button :sweetness_rating, rating_key,
+            class: "hidden peer sweetness-radio",
+            checked: (f.object.sweetness_rating.to_s == rating_key) %>
             <span class="rating-indicator p-2 rounded-full transition-all duration-200 <%= hover_colors[rating_key] %> ">
               <%= image_tag rating_images[rating_key], class: "icon-size pointer-events-none" %>
             </span>


### PR DESCRIPTION
## 概要
- 編集画面で、ラジオボタンの色が正しく反映されてない不具合を修正しました。
- `data: { turbo_permanent: true }`を使わず、JSでイベントリスナーを再登録・初期化することで、編集時も新規作成時も状態が正しく反映されるようにしました。

## 🔧 主な変更点
- sweetness_radio_highlight.jsで、Turbo描画ごとにイベントリスナーをリセット・再登録
- change/inputイベントの両方で色付け処理を実行
- Turbo Permanentは使用せず、サーバー側の値が常に正しく反映されるようにした

## 📋 なぜ発生していたか
`data: { turbo_permanent: true }`をラジオボタンに付与していたため、Turboによる再描画時にもDOMから削除されず、色や選択状態がそのまま保持されていた。

-> このおかげでバリデーションエラー後は選択状態や色が保持されていたが、編集画面では前回の値がそのまま残り、新しい値に切り替わらない問題が発生していた。

## ✅ 動作確認
- [x] 編集画面で既存の値が正しく反映されること
- [x] バリデーションエラー後でも、ラジオボタン選択時に色が即時反映されること

close #101 