### PR TITLE
Fix/#103 login signup redirects

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -15,10 +15,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
     resource.update_without_password(params.except("current_password"))
   end
 
-  # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+  def new
+    session[:from_landing] = true if params[:from_landing].present?
+    super
+  end
 
   # POST /resource
   # def create
@@ -60,7 +60,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def after_sign_up_path_for(resource)
-    root_path
+    if session[:from_landing]
+      session.delete(:from_landing)
+      new_diagnosis_path
+    else
+      root_path
+    end
   end
 
   def after_inactive_sign_up_path_for(resource)

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -43,6 +43,11 @@
         </div>
       </div>
     <% end %>
-
+    <div class="flex justify-center p-4 text-neutral">
+      すでにアカウントをお持ちの方は
+      <%= link_to new_user_session_path, class: "underline-offset-4 hover:underline transition-all" do %>
+        こちら
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -38,6 +38,12 @@
         <%= f.submit "ログイン", class: "bg-accent button-primary" %>
       </div>
     <% end %>
+    <div class="flex justify-center p-4 text-neutral">
+      ユーザー登録の方は
+      <%= link_to new_user_registration_path, class: "underline-offset-4 hover:underline transition-all" do %>
+      こちら
+    <% end %>
+    </div>
   </div>
 </main>
 

--- a/app/views/static_pages/_top_diagnosis_guide.html.erb
+++ b/app/views/static_pages/_top_diagnosis_guide.html.erb
@@ -14,7 +14,7 @@
     <% if user_signed_in? %>
       <%= link_to "診断してみる！", new_diagnosis_path %>
     <% else %>
-      <%= link_to "登録して診断する！", new_user_registration_path %>
+      <%= link_to "登録して診断する！", new_user_registration_path(from_landing: 1) %>
     <% end %>
     </div>
 


### PR DESCRIPTION
## 概要
ユーザー登録後の画面遷移を修正し、ログイン/新規登録画面に相互リンクを追加しました。  

## 🔧主な変更点
- 新規登録後の遷移先を分岐
- ログイン画面に「ユーザー登録の方はこちら」を追加  
- 新規登録画面に「すでにアカウントをお持ちの方はこちら」を追加  

## ✅ 確認事項
- トップページ：`登録して診断する`ボタンの場合、登録後に診断画面へ遷移することを確認
- ヘッダー：`新規登録`ボタンの場合、登録後にトップページへ遷移することを確認

close #103 