### PR TITLE
fix: 未実装機能のUI改善（ボタンの無効化・「準備中」の表示）

### DIFF
--- a/app/views/diagnoses/show.html.erb
+++ b/app/views/diagnoses/show.html.erb
@@ -33,7 +33,10 @@
     </div>
 
     <div class="flex flex-col items-center gap-6 p-8">
-      <%= link_to "X で結果をシェアする", "#", class: "bg-accent button-secondary" %>
+      <%= link_to "#", class: "bg-accent button-secondary opacity-60 pointer-events-none flex flex-col items-center" do %>
+        X でシェアする
+        <span class="text-sm text-center text-error">※ 準備中</span>
+      <% end %>
       <%= link_to "閉じる", posts_path, data: { turbo: false }, class: "bg-accent ring-accent button-close" %>
     </div>
   </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,9 +1,9 @@
-<div class="bg-base-100 justify-center text-center rounded-4xl m-4">
+<div class="bg-base-100 justify-center text-center rounded-4xl m-4 opacity-60 pointer-events-none">
   <p>全体に公開する</p>
   <div class="flex space-x-4 p-4 gap-5 md:gap-20">
 
     <label class="label cursor-pointer flex items-center space-x-2 py-1 rounded">
-      <input type="radio" name="visibility" value="public" class="radio radio-secondary" checked />
+      <input type="radio" name="visibility" value="public" class="radio radio-secondary" />
       <span>公開</span>
     </label>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,14 +1,16 @@
-<div class="p-2 md:p-4">
+<div class="p-2 md:p-4 opacity-60 ">
   <div class="flex flex-col p-6 items-center justify-center w-full max-w-xl mx-auto bg-base-200 rounded-2xl">
     <div class="w-full max-w-lg">
       <!-- 検索フォーム -->
       <div class="flex justify-center items-center gap-4 mb-3 w-full">
         <input 
           type="search" 
-          class="flex-1 min-w-0 bg-base-100 p-2 rounded-full ring-2 ring-[var(--color-base-400)]" 
+          class="flex-1 min-w-0 bg-base-100 p-2 rounded-full ring-2 ring-[var(--color-base-400)] pointer-events-none"
           placeholder="キーワードを入力"
-        >
-        <button class="flex-shrink-0 rounded-full ring-secondary px-4 py-2 text-neutral ring-4 transition duration-200 bg-base-100 hover:brightness-96">
+          disabled >
+        <button
+          class="flex-shrink-0 rounded-full ring-secondary px-4 py-2 text-neutral ring-4 transition duration-200 bg-base-100 hover:brightness-96 opacity-60 pointer-events-none"
+          disabled >
           検索
         </button>
       </div>
@@ -29,20 +31,21 @@
   ] %>
 
   <% options.each_with_index do |opt, idx| %>
-    <label class="cursor-pointer">
-        <%= tag.input type: "radio",
+    <label class="cursor-pointer <%= 'opacity-60 pointer-events-none' if opt[:value] == 'recommend' %>">
+      <%= tag.input type: "radio",
                     name: "tab",
                     value: opt[:value],
                     class: "hidden peer",
-                    checked: idx.zero? %>
-        <div class="rounded-2xl px-5 py-3 md:px-8 text-neutral ring-4 transition duration-200 hover:brightness-96
-                    peer-checked:ring-accent peer-checked:bg-base-100
-                    ring-base-300 bg-[var(--color-base-400)]">
+                    checked: idx.zero?,
+                    disabled: (opt[:value] == 'recommend') %>
+      <div class="rounded-2xl px-5 py-3 md:px-8 text-neutral ring-4 transition duration-200
+                  peer-checked:ring-accent peer-checked:bg-base-100
+                  ring-base-300 bg-[var(--color-base-400)]">
         <% if opt[:img] %>
-            <%= image_tag opt[:img], class: "h-8 w-8 inline-block mr-2" %>
+          <%= image_tag opt[:img], class: "h-8 w-8 inline-block mr-2" %>
         <% end %>
         <%= opt[:label] %>
-        </div>
+      </div>
     </label>
   <% end %>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -105,7 +105,7 @@
             </span>
             <span class="flex items-center gap-1">
               <div class="rating gap-1">
-                <input type="radio" name="rating-3" class="mask mask-heart bg-primary" aria-label="2 star">
+                <input type="radio" name="rating-3" class="mask mask-heart bg-primary pointer-events-none" aria-label="2 star">
               </div>
               いいね！
             </span>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -6,7 +6,7 @@
       </span>
     <% end %>
 
-    <%= link_to "#", class: "flex flex-col items-center justify-center leading-none" do %>
+    <%= link_to "#", class: "flex flex-col items-center justify-center leading-none opacity-60 " do %>
       <span class="p-2 rounded-full md:hover:bg-base-200">
       <%= image_tag "footer/magnifying_glass.svg", class: "h-7 w-7 md:h-8 md:w-8" %>
       </span>
@@ -18,13 +18,13 @@
       </span>
     <% end %>
 
-   <%= link_to "#", class: "flex flex-col items-center justify-center leading-none" do %>
+   <%= link_to "#", class: "flex flex-col items-center justify-center leading-none opacity-60 " do %>
       <span class="p-2 rounded-full md:hover:bg-base-200">
       <%= image_tag "footer/bell.svg", class: "h-7 w-7 md:h-8 md:w-8" %>
       </span>
     <% end %>
 
-    <%= link_to "#", class: "flex flex-col items-center justify-center leading-none" do %>
+    <%= link_to "#", class: "flex flex-col items-center justify-center leading-none opacity-60 " do %>
       <span class="p-2 rounded-full md:hover:bg-base-200">
       <%= image_tag "footer/user_circle.svg", class: "h-7 w-7 md:h-9 md:w-9" %>
       </span>


### PR DESCRIPTION
## 概要
未実装の機能について、ユーザーが誤って「使える」と勘違いしないようにUIを調整しました。  

### 変更点
- 未実装ボタンのクリック無効化  
  - いいね  
  - 公開・非公開  
  - 検索フォーム・検索  
  - あなたにオススメ！  

- `Xでシェアする` ボタンに **「準備中」** のテキストを表示  

- フッター未実装アイコンにグレーアウトを適用  
  - 検索  
  - 通知  
  - ユーザー  

close #111 
