### PR TITLE
fix: GA4を本番環境でのみ読み込むよう環境分離対応

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,15 +48,17 @@
     </style>
   </head>
 
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WK4D3KRCVZ"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+  <% if Rails.env.production? %>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WK4D3KRCVZ"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-    gtag('config', 'G-WK4D3KRCVZ');
-  </script>
+      gtag('config', '<%= ENV['GA_TRACKING_ID'] %>');
+    </script>
+  <% end %>
 
   <body class="min-h-screen flex flex-col bg-center bg-no-repeat bg-fixed bg-cover font-kiwi">
     <%= render 'shared/header' %>


### PR DESCRIPTION
# 概要
Google Analytics 4（GA4）を本番データのみ読み込むよう修正

## 実装内容
- `Rails.env.production?`で本番環境のみGA4読み込み
- Render側の環境変数にGA番号を設定

## 確認事項
- [ ] 本番環境でのみGA4が動作することを確認
- [x] コンソールでRails環境を確認

close #125 