### PR TITLE
Feature/#124 product model creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ erDiagram
     
     %% === 投稿・評価・カテゴリ関連 ===
     posts ||--|| post_sweetness_scores : "1:1"
-    posts }o--|| categories : "多対1"
+    products ||--o{ posts : "1対多"
+    products }o--|| categories : "多対1"
 
     %% === ユーザーのアクション（いいね・コメント・通知・ブックマーク） ===
     users ||--o{ likes : "1:多"

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,11 +7,13 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
+    @post.build_product
     @post.build_post_sweetness_score
   end
 
   def create
     @post = current_user.posts.build(post_params)
+    @post.build_product if @post.product.nil?
     if @post.save
       redirect_to posts_path, notice: t("defaults.flash_message.created", item: Post.model_name.human)
     else
@@ -48,7 +50,8 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:product_name, :manufacturer, :category_id, :sweetness_rating, :review, :image,
+    params.require(:post).permit(:sweetness_rating, :review,
+    product_attributes: [ :name, :manufacturer, :category_id, :image ],
     post_sweetness_score_attributes: [
       :sweetness_strength, :aftertaste_clarity, :natural_sweetness, :coolness, :richness
     ]

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,0 +1,4 @@
+class ProductsController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,0 +1,2 @@
+module ProductsHelper
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,13 +1,12 @@
 class Post < ApplicationRecord
-  validates :product_name, presence: true, length: { maximum: 25 }
-  validates :manufacturer, presence: true
   validates :sweetness_rating, presence: true
   validates :post_sweetness_score, presence: true
   validate :image_type_and_size
-  validates :review, length: { maximum: 300 }
+  validates :review, length: { maximum: 500 }
 
   belongs_to :user
-  belongs_to :category
+  belongs_to :product
+  accepts_nested_attributes_for :product, update_only: true
 
   has_one_attached :image
   has_one :post_sweetness_score, dependent: :destroy

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,0 +1,10 @@
+class Product < ApplicationRecord
+  validates :name, presence: true, length: { maximum: 40 }
+  validates :manufacturer, presence: true
+  validates :name, uniqueness: { scope: :manufacturer, message: "とメーカーの組み合わせは既に存在します" }
+
+
+  belongs_to :category
+  has_many :posts, dependent: :destroy
+  has_one_attached :image
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,7 +50,7 @@
 
   <% if Rails.env.production? %>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WK4D3KRCVZ"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV["GA_TRACKING_ID"] %>"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,61 +1,70 @@
 <div class="justify-center text-center rounded-4xl m-4">
 
-    <%= form_with model: @post, local: true, class: "p-4 md:p-2 space-y-6" do |f| %>
-      <% if @post.errors.any? %>
-        <div class="error-messages text-error bg-base-100 p-2 md:p-4 rounded-4xl ring-2 ring-error">
-          <ul>
-            <% @post.errors.full_messages.each do |message| %>
-              <li><%= message %></li>
-            <% end %>
-          </ul>
+  <%= form_with model: @post, local: true, class: "p-4 md:p-2 space-y-6" do |f| %>
+    <% if @post.errors.any? %>
+      <div class="error-messages text-error bg-base-100 p-2 md:p-4 rounded-4xl ring-2 ring-error">
+        <ul>
+          <% @post.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <%# --- 商品情報 --- %>
+    <%= f.fields_for :product do |p| %>
+      <div class="form-control">
+        <% if f.object.new_record? %>
+          <%= p.label :image, t("products.image"), class: "label p-2 text-neutral" %>
+          <%= p.file_field :image,
+              class: "block w-full max-w-xs mx-auto text-sm text-base-300
+                      file:mr-4 file:py-2 file:px-2 bg-base-100 rounded-xl 
+                      ring-2 ring-[var(--color-base-400)]
+                      file:rounded-l-lg
+                      file:text-sm
+                      file:bg-accent file:transition file:duration-200 file:hover:brightness-96
+                      file:text-neutral
+                      cursor-pointer" %>
+        <% else %>
+          <% if @post.product.image.attached? &&
+                @post.product.image.blob.present? &&
+                @post.product.image.blob.persisted? &&
+                @post.product.image.filename.to_s != "default.png" %>
+            <%= p.label :image, t("products.image"), class: "label p-2 text-neutral" %>
+            <div class="flex justify-center">
+              <%= image_tag @post.product.image.variant(resize_to_fill: [400, 400], format: :webp, saver: { quality: 85 }),
+                            class: "w-50 h-50 object-cover" %>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+
+    <%= f.fields_for :product do |p| %>
+      <% if f.object.new_record? %>
+        <div class="form-control">
+          <%= p.label :name, t("products.name"), class: "label p-2 text-neutral" %>
+          <%= p.text_field :name, class: "input input-bordered w-full" %>
+        </div>
+
+        <div class="form-control">
+          <%= p.label :manufacturer, t("products.manufacturer"), class: "label p-1 md:p-2 text-neutral" %>
+          <%= p.select :manufacturer,
+                options_for_select(I18n.t("products.manufacturers.list"), @post.product.manufacturer),
+                { prompt: "メーカーを選択" },
+                class: "select select-bordered w-full" %>
+        </div>
+
+        <div class="form-control">
+          <%= p.label :category_id, t("products.category"), class: "label p-2 text-neutral" %>
+          <%= p.select :category_id,
+                options_from_collection_for_select(Category.all, :id, :name, @post.product.category_id),
+                { prompt: "カテゴリを選択" },
+                class: "select select-bordered w-full" %>
         </div>
       <% end %>
+    <% end %>
 
-    <div class="form-control">
-      <%= f.label :product_image, t("posts.new.product_image"), class: "label p-2 text-neutral" %>
-
-      <% if @post.image.attached? &&
-      @post.image.attachment.blob.present? &&
-      @post.image.attachment.blob.persisted? %>
-        <div class="flex justify-center">
-          <%= image_tag @post.image.variant(resize_to_fill: [400, 400], format: :webp, saver: { quality: 85 }), class: "w-50 h-50 object-cover" %>
-        </div>
-        <p class="text-sm text-neutral mb-2 text-center leading-relaxed">
-          投稿されている画像は上記です。<br>（変更する場合は下から選択してください）
-        </p>
-      <% end %>
-
-      <%= f.file_field :image,
-          class: "block w-full max-w-xs mx-auto text-sm text-base-300
-                  file:mr-4 file:py-2 file:px-2 bg-base-100 rounded-xl 
-                  ring-2 ring-[var(--color-base-400)]
-                  file:rounded-l-lg
-                  file:text-sm
-                  file:bg-accent file:transition file:duration-200 file:hover:brightness-96
-                  file:text-neutral
-                  cursor-pointer" %>
-    </div>
-
-    <div class="form-control">
-      <%= f.label :product_name, t("posts.new.product_name"), class: "label p-2 text-neutral" %>
-      <%= f.text_field :product_name, class: "input input-bordered w-full" %>
-    </div>
-
-    <div class="form-control">
-      <%= f.label :manufacturer, t("posts.new.manufacturer"), class: "label p-1 md:p-2 text-neutral" %>
-      <%= f.select :manufacturer,
-            options_for_select(I18n.t("posts.manufacturers.list"), @post.manufacturer),
-            { prompt: "メーカーを選択" },
-            class: "select select-bordered w-full" %>
-    </div>
-
-    <div class="form-control">
-      <%= f.label :category_id, t('posts.new.category_id'), class: "label p-2 text-neutral" %>
-      <%= f.select :category_id,
-            options_from_collection_for_select(Category.all, :id, :name, @post.category_id),
-            { prompt: "カテゴリを選択" },
-            class: "select select-bordered w-full" %>
-    </div>
 
     <div class="form-control">
       <%= f.label :sweetness_rating, t('posts.new.sweetness_rating'), class: "label p-2 md:p-4 text-neutral" %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,12 +1,12 @@
 <div class="w-full p-3">
   <!-- カード -->
-  <div class="card bg-base-200 p-4 md:px-4 md:py-5 shadow-sm min-h-52 rounded-4xl flex flex-col md:flex-row relative">
+  <div class="card bg-base-200 p-2 shadow-sm min-h-52 rounded-4xl flex flex-col md:flex-row relative">
     
     <!-- 画像 -->
     <figure class="flex-shrink-0 w-full md:w-52">
       <div class="aspect-square overflow-hidden rounded-none">
-        <% if post.image.attached? %>
-          <%= image_tag post.image.variant(resize_to_fill: [400, 400], format: :webp, saver: { quality: 85 }), class: "w-45 h-45 object-cover" %>
+        <% if post.product.image.attached? %>
+          <%= image_tag post.product.image.variant(resize_to_fill: [400, 400], format: :webp, saver: { quality: 85 }), class: "w-45 h-45 object-cover" %>
         <% else %>
           <%= image_tag "default_image.png", class: "w-45 h-45 object-cover" %>
         <% end %>
@@ -20,16 +20,16 @@
           <%= post.user.name %> ｜ <%= time_ago_in_words(post.created_at) %>前
         </p>
         <%= link_to post_path(post) do %>
-        <div class="flex items-center justify-between mb-3 text-base-300"><%= post.manufacturer %></div>
+        <div class="flex items-center justify-between py-1 text-base-300"><%= post.product.manufacturer %></div>
           <div class="flex items-center justify-between mb-3">
-            <div class="card-title text-md md:text-lg line-clamp-2"><%= post.product_name %></div>
+            <div class="card-title text-md md:text-lg line-clamp-2"><%= post.product.name %></div>
           </div>
         <% end %>
         <p class="text-sm"><%= truncate(post.review, length: 25, omission: '...') %></p>
       </div>
 
       <!-- 評価部分 -->
-      <div class="flex-shrink-0 mt-3">
+      <div class="flex-shrink-0 py-1">
         <% rating_images = {
           "lack_of_sweetness" => "smiley-meh.svg",
           "could_be_sweeter" => "smiley-blank.svg",
@@ -46,7 +46,7 @@
           "too_sweet" => "bg-secondary"
         } %>
 
-        <div class="inline-flex items-center rounded-2xl p-2 gap-2 py-3 px-4 text-neutral text-base <%= bg_colors[post.sweetness_rating] %>">
+        <div class="inline-flex items-center rounded-2xl gap-2 py-3 px-4 text-neutral text-base <%= bg_colors[post.sweetness_rating] %>">
           <%= image_tag rating_images[post.sweetness_rating], class: "h-8 w-8" %>
           <p><%= I18n.t("enums.post.sweetness_rating.#{post.sweetness_rating}") %></p>
         </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,6 +1,7 @@
 <div class="p-2 md:p-4">
-  <div class="flex flex-col p-2 md:p-6 items-center justify-center w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
-    <h1 class="text-center text-xl md:text-2xl p-4 border-b border-gray-300 w-full">
+  <div class="flex flex-col p-2 md:p-4 items-center justify-center w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
+    <h1 class="text-center text-xl md:text-2xl p-4 border-b border-gray-300 w-full leading-relaxed">
+     「<%= @post.product.name %>」<br>
       <%= t('.title') %></h1>
    <%= render 'form', post: @post %>
   </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,28 +1,4 @@
-<div class="p-2 md:p-4 opacity-60 ">
-  <div class="flex flex-col p-6 items-center justify-center w-full max-w-xl mx-auto bg-base-200 rounded-2xl">
-    <div class="w-full max-w-lg">
-      <!-- 検索フォーム -->
-      <div class="flex justify-center items-center gap-4 mb-3 w-full">
-        <input 
-          type="search" 
-          class="flex-1 min-w-0 bg-base-100 p-2 rounded-full ring-2 ring-[var(--color-base-400)] pointer-events-none"
-          placeholder="キーワードを入力"
-          disabled >
-        <button
-          class="flex-shrink-0 rounded-full ring-secondary px-4 py-2 text-neutral ring-4 transition duration-200 bg-base-100 hover:brightness-96 opacity-60 pointer-events-none"
-          disabled >
-          検索
-        </button>
-      </div>
-      <div class="text-sm text-left p-2">
-        詳細検索 +
-      </div>
-      <div class="text-sm text-center text-error">
-        ※ 準備中
-      </div>
-    </div>
-  </div>
-</div>
+<%= render "shared/search" %>
 
 <div class="flex flex-col md:flex-row justify-center items-center text-center text-base md:text-xl p-6 gap-10">
   <% options = [

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -7,8 +7,8 @@
     <div class="flex flex-col justify-center items-center sm:flex-row sm:items-start sm:gap-6">
       <!-- 商品画像 -->
       <div class="aspect-square overflow-hidden p-4">
-        <% if @post.image.attached? %>
-          <%= image_tag @post.image.variant(resize_to_fill: [400, 400], format: :webp, saver: { quality: 85 }), class: "w-50 h-50 object-cover" %>
+        <% if @post.product.image.attached? %>
+          <%= image_tag @post.product.image.variant(resize_to_fill: [400, 400], format: :webp, saver: { quality: 85 }), class: "w-50 h-50 object-cover" %>
         <% else %>
           <%= image_tag "default_image.png", class: "w-50 h-50 object-cover" %>
         <% end %>
@@ -16,7 +16,7 @@
 
       <div class="flex flex-col justify-start items-start gap-2 md:gap-5 text-neutral px-10 md:px-0 py-6">
         <div class="text-xl">
-          <%= @post.product_name %>
+          <%= @post.product.name %>
         </div>
         
         <div class="flex flex-col text-base">

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,0 +1,18 @@
+<div class="p-1 md:p-4">
+  <div class="flex flex-col p-2 md:p-6 items-center justify-center w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
+    <h1 class="text-center text-xl md:text-2xl p-4 border-b border-gray-300 w-full">
+      <%= t('.title') %></h1>
+
+      <%= render 'shared/search' %>
+
+      <div class="p-4">
+        <%= link_to new_post_path, class: "bg-primary rounded-full p-2 md:p-4 inline-flex items-center gap-2 hover:bg-primary/90 transition-colors duration-200 no-underline" do %>
+        <%= image_tag "smiley-wink.svg", class: "h-9 w-9 md:h-10 md:w-10 flex-shrink-0" %>
+        <span class="text-sm justify-center text-center md:text-base">
+            商品が見つからない場合、<br>
+            君のあまピタ評価をみんなに知らせよう！
+        </span>
+        <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -12,7 +12,7 @@
       </span>
     <% end %>
 
-    <%= link_to new_post_path, class: "flex flex-col items-center" do %>
+    <%= link_to products_path, class: "flex flex-col items-center" do %>
       <span class="p-2 rounded-full md:hover:bg-[var(--color-base-400)]">
       <%= image_tag "footer/plus_circle.svg", class: "icon-size" %>
       </span>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -1,0 +1,24 @@
+<div class="p-2 md:p-4 opacity-70 ">
+  <div class="flex flex-col p-6 items-center justify-center w-full max-w-xl mx-auto bg-base-200 rounded-2xl">
+    <div class="w-full max-w-lg">
+      <div class="flex justify-center items-center gap-4 mb-3 w-full">
+        <input 
+          type="search" 
+          class="flex-1 min-w-0 bg-base-100 p-2 rounded-full ring-2 ring-[var(--color-base-400)] pointer-events-none"
+          placeholder="キーワードを入力"
+          disabled >
+        <button
+          class="flex-shrink-0 rounded-full ring-secondary px-4 py-2 text-neutral ring-4 transition duration-200 bg-base-100 hover:brightness-96 opacity-60 pointer-events-none"
+          disabled >
+          検索
+        </button>
+      </div>
+      <div class="text-sm text-left p-2">
+        詳細検索 +
+      </div>
+      <div class="text-sm text-center text-error">
+        ※ 準備中
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -5,6 +5,7 @@ ja:
       post: 投稿
       category: カテゴリ
       sweetness_type: 甘さタイプ
+      product: 商品
     attributes:
       user:
         current_password: "現在のパスワード"
@@ -13,14 +14,16 @@ ja:
         password_confirmation: "確認用パスワード"
         remember_me: "ログイン情報を記憶する"
       post:
-        product_name: 商品名
-        manufacturer: メーカー
         sweetness_rating: あまピタ度
-        category: カテゴリ
         image: 画像
         review: レビュー
       category:
         name: "カテゴリ名"
+      product:
+        name: 商品名
+        manufacturer: メーカー
+        category: カテゴリ
+        image: 画像
     errors:
       models:
         post:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,15 +19,22 @@ ja:
   posts:
     new:
       title: あまピタ評価の登録
-      product_name: 商品名
-      manufacturer: メーカー
-      category_id: カテゴリ
       sweetness_rating: あまピタ度
       post_sweetness_score: あまさ評価
       review: レビュー
-      product_image: 商品の画像
+      image: 商品画像
+      product: 商品
+      product_image: 商品画像
     edit:
       title: あまピタ評価の編集
+  products:
+    title: 商品の登録
+    image: 商品の画像
+    name: 商品名
+    manufacturer: メーカー
+    category: カテゴリ
+    index:
+      title: あまピタ評価する商品を検索
     manufacturers:
       list:
         - 明治

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   get "diagnoses/result/:token", to: "diagnoses#show", as: :diagnosis_result
 
   resources :posts, only: [ :index, :new, :create, :edit, :show, :update, :destroy ]
-
+  resources :products, only: [ :index ]
   get "up" => "rails/health#show", as: :rails_health_check
 
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker

--- a/db/migrate/20250825131551_create_products.rb
+++ b/db/migrate/20250825131551_create_products.rb
@@ -1,0 +1,13 @@
+class CreateProducts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :products do |t|
+      t.references :category, null: false, foreign_key: true
+      t.string :name, null: false
+      t.string :manufacturer, null: false
+
+      t.timestamps
+    end
+
+    add_index :products, [ :name, :manufacturer ], unique: true
+  end
+end

--- a/db/migrate/20250825134141_add_product_id_to_posts.rb
+++ b/db/migrate/20250825134141_add_product_id_to_posts.rb
@@ -1,0 +1,5 @@
+class AddProductIdToPosts < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :posts, :product, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20250825143037_remove_old_columns_from_posts.rb
+++ b/db/migrate/20250825143037_remove_old_columns_from_posts.rb
@@ -1,0 +1,7 @@
+class RemoveOldColumnsFromPosts < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :posts, :product_name, :string
+    remove_column :posts, :manufacturer, :string
+    remove_reference :posts, :category, foreign_key: true
+  end
+end

--- a/db/migrate/20250826103617_change_product_id_not_null_in_posts.rb
+++ b/db/migrate/20250826103617_change_product_id_not_null_in_posts.rb
@@ -1,0 +1,5 @@
+class ChangeProductIdNotNullInPosts < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :posts, :product_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_08_102629) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_26_103617) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,15 +62,23 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_08_102629) do
 
   create_table "posts", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.bigint "category_id", null: false
-    t.string "product_name", null: false
-    t.string "manufacturer", null: false
     t.integer "sweetness_rating", null: false
     t.text "review"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["category_id"], name: "index_posts_on_category_id"
+    t.bigint "product_id", null: false
+    t.index ["product_id"], name: "index_posts_on_product_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "products", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.string "name", null: false
+    t.string "manufacturer", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_products_on_category_id"
+    t.index ["name", "manufacturer"], name: "index_products_on_name_and_manufacturer", unique: true
   end
 
   create_table "sweetness_profiles", force: :cascade do |t|
@@ -116,8 +124,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_08_102629) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "post_sweetness_scores", "posts"
-  add_foreign_key "posts", "categories"
+  add_foreign_key "posts", "products"
   add_foreign_key "posts", "users"
+  add_foreign_key "products", "categories"
   add_foreign_key "sweetness_profiles", "sweetness_types"
   add_foreign_key "sweetness_profiles", "users"
   add_foreign_key "users", "sweetness_types"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,3 +20,20 @@ categories = [
 categories.each do |cat|
   Category.find_or_create_by!(name: cat[:name])
 end
+
+products = [
+  {
+    category_name: "チョコレート",
+    name: "ポッキー",
+    manufacturer: "グリコ"
+  }
+]
+
+products.each do |p|
+  category = Category.find_by!(name: p[:category_name])
+  Product.find_or_create_by!(
+    name: p[:name],
+    manufacturer: p[:manufacturer],
+    category_id: category.id
+  )
+end

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class ProductsControllerTest < ActionDispatch::IntegrationTest
+end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -2,16 +2,12 @@
 
 one:
   user: one
-  category: one
-  product_name: MyString
-  manufacturer: MyString
+  product: one_product
   sweetness_rating: 1
   review: MyText
 
 two:
   user: two
-  category: two
-  product_name: MyString
-  manufacturer: MyString
+  product: two_product
   sweetness_rating: 1
   review: MyText

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -1,0 +1,12 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one_product:
+  category: one
+  name: "MyString"
+  manufacturer: "MyString"
+
+two_product:
+  category: two
+  name: "MyString1"
+  manufacturer: "MyString"
+

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProductTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 実装概要
Productモデルを追加し、既存のPostモデルと紐付けました。  
これに伴い、投稿フォーム・表示・テスト・シード・ルーティングなどを更新しました。

## 主な変更点

### 📦 Productモデル追加
- `app/models/product.rb` を作成
- バリデーション設定（`name` + `manufacturer` のユニーク制約）
- Postモデルとの関連付け（`belongs_to :product` / `has_many :posts`）

### 🛠 マイグレーション更新
- productsテーブル作成
- postsテーブルにproduct_id追加
- postsテーブルから旧カラム（product_name, manufacturer, category）削除

### 📝 投稿フォーム・ビュー修正
- `_form.html.erb`：商品選択・画像表示ロジックを追加
  - 投稿時と編集時で条件分岐
- 投稿・編集・一覧・詳細ページを更新
- 共通パーシャル・フッター修正

### 🌱 seeds.rb更新
- Product(仮)データ追加

## 動作確認
- [x] 編集画面では甘さ評価・レビューのみ編集できること
- [x] 投稿を削除しても商品データが削除されないこと
- [x] 登録済みの商品を登録しようとした際にエラーメッセージが表示されること

## 技術的な考慮事項
- 投稿時に既存Productを選択する設計に変更

## 今後の改善予定
- [ ] 管理画面でProductの商品情報の管理機能を追加予定
- [ ] Product画像編集は商品登録者と管理者のみにする予定
- [ ] 投稿フォームのUX改善（商品選択の補助など）


close #124 