### PR TITLE
Feat/#117 seed product data

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,18 @@ erDiagram
     posts {
         bigint id PK "ID"
         int user_id FK "ユーザーID"
-        int category_id FK "カテゴリID"
-        string product_name "商品名"
-        string manufacturer "メーカー名"
+        int product_id FK "商品ID"
         int sweetness_rating "あまピタ度"
         text review "商品の感想"
+        datetime created_at "作成日時"
+        datetime updated_at "更新日時"
+    }
+
+    products {
+        bigint id PK "ID"
+        int category_id FK "カテゴリID"
+        string name "商品名"
+        string manufacturer "メーカー名"
         datetime created_at "作成日時"
         datetime updated_at "更新日時"
     }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,6 +26,46 @@ products = [
     category_name: "チョコレート",
     name: "ポッキー",
     manufacturer: "グリコ"
+  },
+    {
+    category_name: "グミ・ゼリー",
+    name: "果汁グミ ぶどう",
+    manufacturer: "明治"
+  },
+    {
+    category_name: "クッキー・ビスケット",
+    name: "オレオ",
+    manufacturer: "ナビスコ"
+  },
+  {
+    category_name: "ケーキ・洋菓子",
+    name: "プレミアムロールケーキ",
+    manufacturer: "ローソン"
+  },
+  {
+    category_name: "アイス・冷菓",
+    name: "雪見だいふく",
+    manufacturer: "ロッテ"
+  },
+  {
+    category_name: "飲み物",
+    name: "午後の紅茶 ミルクティー",
+    manufacturer: "キリン"
+  },
+  {
+    category_name: "ドーナツ",
+    name: "ポン・デ・リング",
+    manufacturer: "ミスタードーナツ"
+  },
+  {
+    category_name: "スナック菓子",
+    name: "キャラメルコーン",
+    manufacturer: "東ハト"
+  },
+  {
+    category_name: "その他",
+    name: "なめらかプリン",
+    manufacturer: "パステル"
   }
 ]
 


### PR DESCRIPTION
## 概要
seedファイルに8種類の商品データを追加し、READMEを更新しました。

### 📋主な変更点
seedデータを利用して商品情報を登録

### 🔧その他修正事項
Productsテーブル修正のためREADMEを更新
(カラム・Postsテーブルへ外部キーの追加)

### ✅ チェックリスト
- [x] seedファイルが正常に実行できることを確認
- [x] 既存データとの重複がないことを確認

### 🚀 今後の予定
- 画像は本番環境で追加
- 管理画面での登録機能実装
- カテゴリの整理

close #117 