### PR TITLE
Feat/#88 product detail

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -98,3 +98,7 @@
 .category-label-multi {
 @apply absolute inset-0 flex flex-col items-center justify-center text-white text-base md:text-2xl font-bold;
 }
+
+.title-ring {
+@apply px-4 py-2 md:px-5 md:py-2 text-neutral ring-4 rounded-xl bg-base-100 flex flex-row items-center gap-2;
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,4 +1,11 @@
 class ProductsController < ApplicationController
   def index
   end
+
+  def show
+    @product = Product.find(params[:id])
+    @posts = @product.posts.order(created_at: :desc)
+    @average_scores = @product.average_sweetness_scores
+    @user_post = @posts.find_by(user_id: current_user.id) if user_signed_in?
+  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,7 +3,6 @@ class Product < ApplicationRecord
   validates :manufacturer, presence: true
   validates :name, uniqueness: { scope: :manufacturer, message: "とメーカーの組み合わせは既に存在します" }
 
-
   belongs_to :category
   has_many :posts, dependent: :destroy
   has_one_attached :image
@@ -14,5 +13,16 @@ class Product < ApplicationRecord
 
   def perfect_sweetness_count
     posts.where(sweetness_rating: Post.sweetness_ratings[:perfect_sweetness]).size
+  end
+
+  def average_sweetness_scores
+    scores = PostSweetnessScore.where(post_id: posts.select(:id))
+    {
+      sweetness_strength: scores.average(:sweetness_strength),
+      aftertaste_clarity: scores.average(:aftertaste_clarity),
+      natural_sweetness: scores.average(:natural_sweetness),
+      coolness: scores.average(:coolness),
+      richness: scores.average(:richness)
+    }
   end
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -14,7 +14,7 @@
     <%# --- 商品情報 --- %>
     <%= f.fields_for :product do |p| %>
       <div class="form-control">
-        <% if f.object.new_record? %>
+        <% if f.object.new_record? && @post.product.new_record? %>
           <%= p.label :image, t("products.image"), class: "label p-2 text-neutral" %>
           <%= p.file_field :image,
               class: "block w-full max-w-xs mx-auto text-sm text-base-300
@@ -30,7 +30,6 @@
                 @post.product.image.blob.present? &&
                 @post.product.image.blob.persisted? &&
                 @post.product.image.filename.to_s != "default.png" %>
-            <%= p.label :image, t("products.image"), class: "label p-2 text-neutral" %>
             <div class="flex justify-center">
               <%= image_tag @post.product.image.variant(resize_to_fill: [400, 400], format: :webp, saver: { quality: 85 }),
                             class: "w-50 h-50 object-cover" %>
@@ -40,15 +39,26 @@
       </div>
     <% end %>
 
+    <!-- 既存商品の場合 -->
+    <% if @post.product.persisted? %>
+      <%= f.hidden_field :product_id, value: @post.product.id %>
+      <div class="bg-base-100 p-4 rounded-xl text-sm text-neutral">
+        <p>商品名：<%= @post.product.name %></p>
+        <p>メーカー：<%= @post.product.manufacturer %></p>
+        <p>カテゴリ：<%= @post.product.category.name %></p>
+      </div>
+
+    <% else %>
+
+    <!-- 新規商品の場合 -->
     <%= f.fields_for :product do |p| %>
-      <% if f.object.new_record? %>
         <div class="form-control">
           <%= p.label :name, t("products.name"), class: "label p-2 text-neutral" %>
           <%= p.text_field :name, class: "input input-bordered w-full" %>
         </div>
 
         <div class="form-control">
-          <%= p.label :manufacturer, t("products.manufacturer"), class: "label p-1 md:p-2 text-neutral" %>
+          <%= p.label :manufacturer, t("products.manufacturer"), class: "label p-2 text-neutral" %>
           <%= p.select :manufacturer,
                 options_for_select(I18n.t("products.manufacturers.list"), @post.product.manufacturer),
                 { prompt: "メーカーを選択" },
@@ -64,7 +74,6 @@
         </div>
       <% end %>
     <% end %>
-
 
     <div class="form-control">
       <%= f.label :sweetness_rating, t('posts.new.sweetness_rating'), class: "label p-2 md:p-4 text-neutral" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -116,5 +116,14 @@
         </div>
       </div>
     </div>
+
+    <div class="p-2 flex flex-col md:flex-row justify-center items-center text-center">
+      <%= link_to product_path(@post.product) do %>
+        <div class="text-base rounded-2xl px-5 py-3 md:px-8 text-neutral ring-4 transition duration-200
+              ring-accent w-fit bg-white hover-animation">
+          みんなのあまピタ評価はこちら
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,0 +1,170 @@
+<div class="p-2 md:p-4">
+  <div class="p-2 md:p-6 w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
+    <h1 class="text-center text-xl md:text-2xl p-4 border-b border-gray-300 w-full">
+      <%= @product.name %>
+    </h1>
+
+    <div class="flex flex-col justify-center items-center sm:flex-row sm:items-start sm:gap-6">
+      <!-- 商品画像 -->
+      <div class="aspect-square overflow-hidden p-4">
+        <% if @product.image.attached? %>
+          <%= image_tag @product.image.variant(resize_to_fill: [400, 400],
+            format: :webp, saver: { quality: 85 }), class: "w-30 md:w-50 h-30 md:h-50 object-cover" %>
+        <% else %>
+          <%= image_tag "default_image.png", class: "w-30 md:w-50 h-30 md:h-50 object-cover" %>
+        <% end %>
+      </div>
+
+      <div class="flex flex-col justify-start items-start gap-2 md:gap-5 text-neutral py-4 md:px-0 md:py-6">
+        <div class="text-sm md:text-base text-base-300">
+          <%= t('.manufacturer') %>：<%= @product.manufacturer %>
+        </div>
+        <div class="text-sm md:text-base text-base-300">
+          <%= t('.category') %>：<%= @product.category.name %>
+        </div>
+
+        <!-- あまピタ人数のカウント -->
+        <div class="w-full md:w-auto justify-center md:block py-4">
+          <% if @product.total_posts.zero? %>
+            <div class="ring-base-300 title-ring">
+              <%= image_tag "smiley-blank.svg", class: "h-8 w-8 md:h-10 md:w-10" %>
+              あまピタ評価はまだありません
+            </div>
+            <div class="mt-8 md:mt-12 text-center">
+                <%= link_to new_post_path(product_id: @product.id), class: "bg-primary rounded-full px-4 py-3 inline-flex items-center gap-3 shadow-sm hover-animation" do %>
+                <%= image_tag "smiley-wink.svg", class: "h-9 w-9 md:h-10 md:w-10 flex-shrink-0" %>
+                <span class="text-sm md:text-base">
+                    この商品のあまピタ評価をする
+                </span>
+            <% end %>
+          </div>
+          <% else %>
+            <div class="ring-primary title-ring">
+              <%= image_tag "smiley-wink.svg", class: "h-8 w-8 md:h-9 md:w-9" %>
+              <p><%= @product.total_posts %>人中<%= @product.perfect_sweetness_count %>人があまピタッ！</p>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <% if @posts.present? %>
+      <!-- チャート -->
+    <div class="flex justify-center p-2 md:p-6">
+      <div class="w-full max-w-lg sm:max-w-xl lg:max-w-xl p-2 border-secondary rounded-3xl bg-base-100">
+        <div class="flex flex-col justify-center items-center p-2 md:p-4 text-base md:text-xl">
+        あまさ評価チャート
+        </div>
+        <div class="mx-auto w-full max-w-md">
+        <% if user_signed_in? && @user_post.present? %>
+            <%= render "shared/average_chart",
+            chart_id: "averageChart",
+            user_data: [
+                @user_post.post_sweetness_score.sweetness_strength,
+                @user_post.post_sweetness_score.aftertaste_clarity,
+                @user_post.post_sweetness_score.natural_sweetness,
+                @user_post.post_sweetness_score.coolness,
+                @user_post.post_sweetness_score.richness
+            ],
+            average_data: [
+                @average_scores[:sweetness_strength],
+                @average_scores[:aftertaste_clarity],
+                @average_scores[:natural_sweetness],
+                @average_scores[:coolness],
+                @average_scores[:richness]
+            ] %>
+        <% else %>
+            <%= render "shared/chart",
+            chart_id: "radarChart",
+            data: [
+                @average_scores[:sweetness_strength],
+                @average_scores[:aftertaste_clarity],
+                @average_scores[:natural_sweetness],
+                @average_scores[:coolness],
+                @average_scores[:richness]
+            ] %>
+        <% end %>
+        </div>
+      </div>
+    </div>
+
+      <!-- ユーザーレビュー -->
+      <div class="bg-white px-4 py-6 md:p-2 max-w-2xl mx-auto rounded-4xl flex flex-col items-center">
+        <div class="p-2 text-base md:text-xl">
+          ユーザーレビュー
+        </div>
+
+        <% @posts.each do |post| %>
+        
+          <div class="py-4 border-b border-base-300 last:border-b-0">
+            <%= link_to post_path(post) do %>
+              <div class="grid grid-cols-3 md:hover:opacity-70 items-center">
+                <!-- ユーザー情報 -->
+                <div class="col-span-1 flex flex-col items-center justify-center">
+                  <%= image_tag "footer/user_circle.svg", class: "h-12 w-12" %>
+                  <span class="mt-1 text-sm font-medium"><%= post.user.name %></span>
+                </div>
+
+                <!-- 甘さ評価 -->
+                <div class="col-span-2 flex flex-col gap-2 text-left">
+                  <% rating_images = {
+                    "lack_of_sweetness" => "smiley-meh.svg",
+                    "could_be_sweeter" => "smiley-blank.svg",
+                    "perfect_sweetness" => "smiley-wink.svg",
+                    "slightly_too_sweet" => "smiley-nervous.svg",
+                    "too_sweet" => "smiley-x-eyes.svg"
+                  } %>
+
+                  <% bg_colors = {
+                    "lack_of_sweetness" => "bg-accent",
+                    "could_be_sweeter" => "bg-accent",
+                    "perfect_sweetness" => "bg-primary",
+                    "slightly_too_sweet" => "bg-secondary",
+                    "too_sweet" => "bg-secondary"
+                  } %>
+                  
+                  <div class="inline-flex items-center rounded-2xl gap-2 px-3 md:px-5 py-2 md:py-4
+                              text-neutral text-sm md:text-base w-fit <%= bg_colors[post.sweetness_rating] %>">
+                    <%= image_tag rating_images[post.sweetness_rating], class: "h-6 w-6" %>
+                    <p><%= I18n.t("enums.post.sweetness_rating.#{post.sweetness_rating}") %></p>
+                  </div>
+
+                  <!-- レビュー -->
+                  <div class="p-2">
+                    <p class="text-sm text-neutral"><%= truncate(post.review, length: 30, omission: '...') %></p>
+                  </div>
+                  <div class="p-2 text-sm text-base-300 text-right">
+                    <%= l post.created_at %>
+                  </div>
+                </div>
+              </div>
+
+              <% if user_signed_in? && current_user.own?(post) %>
+                <div class="flex justify-end gap-4 mt-2">
+                  <%= link_to edit_post_path(post), class: "text-sm ring-accent action-button", data: { turbo: false } do %>
+                    編集
+                  <% end %>
+                  <%= link_to post_path(post), class: "text-sm ring-secondary action-button", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+                    削除
+                  <% end %>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+
+        <% user_reviewed = user_signed_in? && @posts.any? { |post| post.user_id == current_user.id } %>
+        <% unless user_reviewed %>
+          <div class="mt-8 md:mt-12 text-center">
+            <%= link_to new_post_path(product_id: @product.id), class: "bg-primary rounded-full px-4 py-3 inline-flex items-center gap-3 shadow-sm hover-animation" do %>
+              <%= image_tag "smiley-wink.svg", class: "h-9 w-9 md:h-10 md:w-10 flex-shrink-0" %>
+              <span class="text-sm md:text-base">
+                この商品のあまピタ評価をする
+              </span>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_average_chart.html.erb
+++ b/app/views/shared/_average_chart.html.erb
@@ -1,0 +1,52 @@
+<canvas id="averageChart" width="400" height="400"></canvas>
+
+<script>
+  document.addEventListener("turbo:load", function () {
+    const ctx = document.getElementById("averageChart");
+    if (!ctx) return;
+
+    // 既存チャートを破棄（turboで複数回ロードされる対策）
+    if (Chart.getChart(ctx)) {
+      Chart.getChart(ctx).destroy();
+    }
+
+    // 画面幅でborderWidthを切り替え
+    const borderWidth = window.innerWidth < 768 ? 2 : 4;
+    new Chart(ctx, {
+      type: 'radar',
+      data: {
+        labels: ["甘みの強さ", ["後味のキレ/","スッキリ感"], "自然な甘さ", "爽快感", "甘さの深み/コク"],
+        datasets: [
+          {
+            label: "あなたの評価",
+            data: [<%= user_data.map(&:to_i).join(", ") %>],
+            backgroundColor: 'rgba(245, 182, 199, 0.4)',
+            borderColor: 'rgba(245, 182, 199, 0.6)',
+            borderWidth: borderWidth,
+            pointBackgroundColor: 'rgba(245, 182, 199, 0.6)'
+          },
+          {
+            label: "みんなの評価",
+            data: [<%= average_data.map(&:to_i).join(", ") %>],
+            backgroundColor: 'rgba(153, 215, 170, 0.4)',
+            borderColor: 'rgba(153, 215, 170, 0.6)',
+            borderWidth: borderWidth,
+            pointBackgroundColor: 'rgba(153, 215, 170, 0.6)',
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        scales: {
+          r: {
+            min: 0,
+            max: 5,
+            ticks: {
+              stepSize: 1
+            }
+          }
+        }
+      }
+    });
+  });
+</script>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,6 +25,8 @@ ja:
       image: 商品画像
       product: 商品
       product_image: 商品画像
+      manufacturer: メーカー
+      category: カテゴリ
     edit:
       title: あまピタ評価の編集
   products:
@@ -33,6 +35,9 @@ ja:
     name: 商品名
     manufacturer: メーカー
     category: カテゴリ
+    show:
+      manufacturer: メーカー
+      category: カテゴリ
     manufacturers:
       list:
         - 明治

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,4 @@
 Rails.application.routes.draw do
-  get "categories/index"
-  get "categories/show"
   devise_for :users, controllers: {
     registrations: "users/registrations",
     sessions: "users/sessions",


### PR DESCRIPTION
## 概要
商品詳細画面の作成と平均チャート表示機能を追加しました。

### 📋 実装内容
- 商品詳細画面 (`products/show.html.erb`) の作成  
- 平均チャート表示用のビュー (`shared/_average_chart.html.erb`) を追加 

### 🔧その他修正
- PostsController の既存投稿処理を修正 
- 不要な `categories/index`、`categories/show` のルーティングを削除  

### 🎨 UI / スタイル関連
- Tailwind CSS による共通レイアウト修正  
- ja.yml に文言追加・修正  

### ✅ 動作確認
- [x] あまピタ人数のカウントが正しく表示される
- [x] 平均チャートとユーザーの評価が正しく描画される   
- [x] 既存の投稿処理が正しく動作する  

### 今後対応予定
- [ ] 自分の評価とみんなの評価をボタンで切り替え表示できる機能をchat.js以外で追加検討
- [ ] レビュー欄のレイアウト修正
- [ ]  平均チャート表示についてはパフォーマンス改善の余地あり
  （現在5回のクエリが発行されているが、生SQLで1回にまとめる方法も考慮要）

close #88 
