### PR TITLE
Feat/#46 search boards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem "omniauth-rails_csrf_protection"
 
 gem "meta-tags"
 
+# ransack
+gem "ransack"
+
 gem "swimming_fish", "~> 0.2.2"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,6 +320,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.0)
+    ransack (4.3.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
@@ -456,6 +460,7 @@ DEPENDENCIES
   pg (~> 1.6)
   puma (>= 5.0)
   rails (~> 7.2.1)
+  ransack
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -102,3 +102,7 @@
 .title-ring {
 @apply px-4 py-2 md:px-5 md:py-2 text-neutral ring-4 rounded-xl bg-base-100 flex flex-row items-center gap-2;
 }
+
+.search-form-button {
+@apply rounded-full px-3 md:px-5 py-2 text-sm text-neutral ring-4 transition duration-200 bg-base-100 hover:brightness-96;  
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,8 @@ class PostsController < ApplicationController
   before_action :authenticate_user!, only: [ :new, :create ]
 
   def index
-    @posts = Post.includes(:user).all.order(created_at: :desc)
+    @q = Post.ransack(params[:q])
+    @posts = @q.result(distinct: true).includes(:user).all.order(created_at: :desc)
   end
 
   def new

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -7,6 +7,6 @@ class Category < ApplicationRecord
   end
 
   def self.ransackable_associations(auth_object = nil)
-    ["products", "posts"]
+    [ "products", "posts" ]
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,12 @@
 class Category < ApplicationRecord
-  has_many :posts
+  has_many :posts, through: :products
   has_many :products
+
+  def self.ransackable_attributes(auth_object = nil)
+    [ "name" ]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["products", "posts"]
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -22,7 +22,7 @@ class Post < ApplicationRecord
   }
 
   def self.ransackable_attributes(auth_object = nil)
-    ["review", "created_at", "sweetness_rating"]
+    [ "review", "created_at", "sweetness_rating" ]
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,6 +6,7 @@ class Post < ApplicationRecord
 
   belongs_to :user
   belongs_to :product
+  has_one :category, through: :product
   accepts_nested_attributes_for :product, update_only: true
 
   has_one_attached :image
@@ -19,6 +20,14 @@ class Post < ApplicationRecord
     slightly_too_sweet: 3,
     too_sweet: 4
   }
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["review", "created_at", "sweetness_rating"]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    [ "product", "user", "category" ]
+  end
 
   private
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -25,4 +25,12 @@ class Product < ApplicationRecord
       richness: scores.average(:richness)
     }
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    [ "name", "manufacturer" ]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["category", "posts"]
+  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -31,6 +31,6 @@ class Product < ApplicationRecord
   end
 
   def self.ransackable_associations(auth_object = nil)
-    ["category", "posts"]
+    [ "category", "posts" ]
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,4 +26,8 @@ class User < ApplicationRecord
   def own?(object)
     id == object&.user_id
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    [ "name" ]
+  end
 end

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,0 +1,110 @@
+<%= search_form_for q, url: posts_path, method: :get,
+    class: 'p-2 md:p-4 flex justify-center',
+    data: { search_clear_target: "form" } do |f| %>
+
+  <div class="bg-base-200 rounded-4xl p-4 md:p-6 max-w-md md:max-w-4xl mx-auto flex flex-col items-center gap-4">
+
+    <!-- キーワード -->
+    <div class="flex flex-row items-center gap-3 px-1">
+      <%= f.search_field :review_or_product_name_or_user_name_or_category_name_or_product_manufacturer_cont, 
+        class: "flex-1 bg-white p-2 rounded-4xl ring-2 w-40 md:w-100 ring-[var(--color-base-400)] text-sm px-4",
+        placeholder: t('defaults.search_word'),
+        data: { search_clear_target: "input" } %>
+
+        <%= f.submit t('defaults.search'),
+          class: "ring-secondary search-form-button text-base" %>
+
+        <button type="button" onclick="location.href='<%= url_for(only_path: true) %>'"
+          class="ring-[var(--color-base-400)] search-form-button text-base whitespace-nowrap">
+          <%= t('defaults.clear') %>
+        </button>
+    </div>
+
+    <!-- 詳細検索 -->
+    <div class="w-full">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 px-8 md:px-6">
+
+          <!-- カテゴリ -->
+          <div class="col-span-1">
+            <%= f.select :category_name_eq,
+                  Category.all.pluck(:name, :name),
+                  { include_blank: t('activerecord.models.category') },
+                  class: "select w-full text-sm bg-white py-2",
+                  data: { search_clear_target: "select" } %>
+          </div>
+
+          <!-- メーカー -->
+          <div class="col-span-1">
+            <%= f.select :product_manufacturer_eq,
+                  I18n.t('products.manufacturers.list'),
+                  { include_blank: t('activerecord.attributes.product.manufacturer') },
+                  class: "select w-full text-sm bg-white",
+                  data: { search_clear_target: "select" } %>
+          </div>
+
+        </div>
+
+        <!-- あまピタ度 -->
+        <div class="mt-6">
+          <div class="form-control">
+            <div class="bg-base-100 p-1 md:p-4 rounded-4xl ring-[var(--color-base-400)] ring-2 w-fit mx-auto">
+              <div class="flex justify-center mb-2">
+                <%= f.label :sweetness_rating_eq, t('activerecord.attributes.post.sweetness_rating'),
+                  class: "label text-neutral text-base text-center" %>
+              </div>
+              <div class="flex flex-wrap justify-center gap-2 md:gap-6 p-1 rounded-4xl text-sm">
+                <% 
+                  rating_images = {
+                    "lack_of_sweetness" => "smiley-meh.svg",
+                    "could_be_sweeter" => "smiley-blank.svg",
+                    "perfect_sweetness" => "smiley-wink.svg",
+                    "slightly_too_sweet" => "smiley-nervous.svg",
+                    "too_sweet" => "smiley-x-eyes.svg"
+                  }
+
+                  hover_colors = {
+                    "lack_of_sweetness" => "hover:bg-accent",
+                    "could_be_sweeter" => "hover:bg-accent", 
+                    "perfect_sweetness" => "hover:bg-primary",
+                    "slightly_too_sweet" => "hover:bg-secondary",
+                    "too_sweet" => "hover:bg-secondary"
+                  }
+
+                  selected_colors = {
+                    "lack_of_sweetness" => "peer-checked:bg-accent",
+                    "could_be_sweeter" => "peer-checked:bg-accent",
+                    "perfect_sweetness" => "peer-checked:bg-primary", 
+                    "slightly_too_sweet" => "peer-checked:bg-secondary",
+                    "too_sweet" => "peer-checked:bg-secondary"
+                  }
+
+                  tooltips = {
+                    "lack_of_sweetness" => "あまさが足りない",
+                    "could_be_sweeter" => "もう少し甘さがほしい",
+                    "perfect_sweetness" => "あまピタ！",
+                    "slightly_too_sweet" => "少しあますぎ",
+                    "too_sweet" => "あますぎ"
+                  }
+                %>
+
+                <% Post.sweetness_ratings.keys.each do |rating_key| %>
+                  <% checked = params.dig(:q, :sweetness_rating_eq).to_s == Post.sweetness_ratings[rating_key].to_s %>
+                  <label class="flex flex-col items-center cursor-pointer tooltip tooltip-bottom" 
+                        data-tip="<%= tooltips[rating_key] %>">
+                    <%= f.radio_button :sweetness_rating_eq, Post.sweetness_ratings[rating_key],
+                        class: "hidden peer sweetness-radio",
+                        checked: checked %>
+
+                    <span class="rating-indicator p-2 rounded-4xl transition-all duration-200 <%= hover_colors[rating_key] %> <%= selected_colors[rating_key] %>">
+                      <%= image_tag rating_images[rating_key], class: "w-9 h-9 pointer-events-none" %>
+                    </span>
+                  </label>
+                <% end %>
+
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+  </div>
+<% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,4 @@
-<%= render "shared/search" %>
+<%= render 'search_form', q: @q, url: posts_path %>
 
 <div class="flex flex-col md:flex-row justify-center items-center text-center text-base md:text-xl p-6 gap-10">
   <% options = [

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,9 @@
 ja:
   defaults:
+    search: 検索
+    clear: クリア
     delete_confirm: "削除しますか？"
+    search_word: キーワードを入力
     flash_message:
       created: "%{item}を作成しました"
       not_created: "%{item}を作成出来ませんでした"


### PR DESCRIPTION
## 概要
Ransackを導入し、投稿一覧画面および関連モデルに検索機能を追加しました。  
検索フォームは日本語翻訳に対応しており、検索条件として投稿名・ユーザー名・カテゴリ・商品名・メーカー名での検索が可能です。

### 🔧 主な変更点
-  Ransack導入
- Post, Category, Product, User モデルに検索可能カラムを定義
  - User モデルは `name` のみ検索可能
- ローカライズ対応
- sweetness_rating はtooltips で説明を表示

### 📝 備考
- User モデルの `ransackable_attributes` で `name` のみ検索可能に設定
- `ransackable_associations` は今回は不要
- 今後、関連モデル経由での検索を追加する場合のみ定義が必要

### ✅ 確認事項
- [x] 複数条件で投稿が表示されること
- [x] プルダウンが locale に定義したものだけ表示されること
- [x] レスポンシブ対応

close #46 