### PR TITLE
refactor: Product関連のバリデーションとビュー・I18n改善

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,5 @@
 class Post < ApplicationRecord
-  validates :sweetness_rating, presence: true
+  validates :sweetness_rating, presence: { message: :select }
   validates :post_sweetness_score, presence: true
   validate :image_type_and_size
   validates :review, length: { maximum: 500 }

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,9 +1,10 @@
 class Product < ApplicationRecord
   validates :name, presence: true, length: { maximum: 40 }
-  validates :manufacturer, presence: true
+  validates :manufacturer, presence: { message: :select }
   validates :name, uniqueness: { scope: :manufacturer, message: "とメーカーの組み合わせは既に存在します" }
+  validates :category_id, presence: { message: :select }
 
-  belongs_to :category
+  belongs_to :category, optional: true
   has_many :posts, dependent: :destroy
   has_one_attached :image
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -15,7 +15,7 @@
     <%= f.fields_for :product do |p| %>
       <div class="form-control">
         <% if f.object.new_record? && @post.product.new_record? %>
-          <%= p.label :image, t("products.image"), class: "label p-2 text-neutral" %>
+          <%= p.label :image, t('activerecord.attributes.product.image'), class: "label p-2 text-neutral" %>
           <%= p.file_field :image,
               class: "block w-full max-w-xs mx-auto text-sm text-base-300
                       file:mr-4 file:py-2 file:px-2 bg-base-100 rounded-xl 
@@ -42,44 +42,56 @@
     <!-- 既存商品の場合 -->
     <% if @post.product.persisted? %>
       <%= f.hidden_field :product_id, value: @post.product.id %>
-      <div class="bg-base-100 p-4 rounded-xl text-sm text-neutral">
-        <p>商品名：<%= @post.product.name %></p>
-        <p>メーカー：<%= @post.product.manufacturer %></p>
-        <p>カテゴリ：<%= @post.product.category.name %></p>
+      <div class="bg-base-100 p-4 rounded-4xl text-sm text-neutral">
+      <span class="text-left inline-block leading-loose">
+        <p><%=t('activerecord.attributes.product.name') %>：<%= @post.product.name %></p>
+        <p><%=t('activerecord.attributes.product.manufacturer') %>：<%= @post.product.manufacturer %></p>
+        <p><%=t('activerecord.attributes.product.category_id') %>：<%= @post.product.category.name %></p>
+      </span>
       </div>
-
     <% else %>
 
     <!-- 新規商品の場合 -->
     <%= f.fields_for :product do |p| %>
-        <div class="form-control">
-          <%= p.label :name, t("products.name"), class: "label p-2 text-neutral" %>
-          <%= p.text_field :name, class: "input input-bordered w-full" %>
+      <div class="form-control">
+        <div class="label p-2 text-neutral flex justify-center items-center space-x-1">
+          <%= p.label :name %>
+          <span class="text-error">*</span>
         </div>
+        <%= p.text_field :name, class: "input input-bordered" %>
+      </div>
 
-        <div class="form-control">
-          <%= p.label :manufacturer, t("products.manufacturer"), class: "label p-2 text-neutral" %>
-          <%= p.select :manufacturer,
-                options_for_select(I18n.t("products.manufacturers.list"), @post.product.manufacturer),
-                { prompt: "メーカーを選択" },
-                class: "select select-bordered w-full" %>
+      <div class="form-control">
+        <div class="label p-2 text-neutral flex justify-center items-center space-x-1">
+          <%= p.label :manufacturer %>
+          <span class="text-error">*</span>
         </div>
+        <%= p.select :manufacturer,
+              options_for_select(I18n.t("products.manufacturers.list"), @post.product.manufacturer),
+              { prompt: t("posts.select.manufacturer") },
+              class: "select select-bordered" %>
+      </div>
 
-        <div class="form-control">
-          <%= p.label :category_id, t("products.category"), class: "label p-2 text-neutral" %>
-          <%= p.select :category_id,
-                options_from_collection_for_select(Category.all, :id, :name, @post.product.category_id),
-                { prompt: "カテゴリを選択" },
-                class: "select select-bordered w-full" %>
+      <div class="form-control">
+        <div class="label p-2 text-neutral flex justify-center items-center space-x-1">
+          <%= p.label :category_id %>
+          <span class="text-error">*</span>
         </div>
-      <% end %>
+        <%= p.select :category_id,
+              options_from_collection_for_select(Category.all, :id, :name, @post.product.category_id),
+              { prompt: t("posts.select.category") },
+              class: "select select-bordered" %>
+      </div>
     <% end %>
+  <% end %>
 
     <div class="form-control">
-      <%= f.label :sweetness_rating, t('posts.new.sweetness_rating'), class: "label p-2 md:p-4 text-neutral" %>
-
-      <div class="flex flex-wrap justify-center gap-4 bg-base-100 p-2 md:p-6 rounded-4xl ring-2 ring-[var(--color-base-400)]">
-        <% 
+      <div class= "label p-2 text-neutral flex justify-center items-center space-x-1" >
+        <%= f.label :sweetness_rating %>
+        <span class="text-error">*</span>
+      </div>
+      <div class="flex flex-wrap justify-center gap-4 bg-base-100 p-2 md:p-5 rounded-4xl ring-2 ring-[var(--color-base-400)]">
+        <%
           rating_images = {
             "lack_of_sweetness" => "smiley-meh.svg",
             "could_be_sweeter" => "smiley-blank.svg",
@@ -123,17 +135,17 @@
     </div>
 
     <%= f.fields_for :post_sweetness_score do |s| %>
-      <div class="p-1">
-        <%= t("posts.new.post_sweetness_score") %>
+      <div class="pb-1">
+        <%= t("activerecord.attributes.post.post_sweetness_score") %>
       </div>
       <div class="flex flex-wrap justify-center gap-4 bg-base-100 p-2 rounded-4xl ring-2 ring-[var(--color-base-400)]">
         <div class="mx-auto space-y-6 p-4 sm:space-y-0 sm:table w-full">
           <% {
-            sweetness_strength: "甘みの強さ :",
-            aftertaste_clarity: "後味のキレ/スッキリ感 :",
-            natural_sweetness: "自然な甘さ :",
-            coolness: "爽快感 :",
-            richness: "甘さの深み/コク :"
+            sweetness_strength: "#{t('activerecord.attributes.sweetness_strength')} :",
+            aftertaste_clarity: "#{t('activerecord.attributes.aftertaste_clarity')} :",
+            natural_sweetness: "#{t('activerecord.attributes.natural_sweetness')} :",
+            coolness: "#{t('activerecord.attributes.coolness')} :",
+            richness: "#{t('activerecord.attributes.richness')} :",
           }.each do |field, label| %>
             <div class="sm:table-row">
               <div class="sm:mb-0 sm:table-cell p-1 sm:pr-4 sm:text-right">
@@ -156,12 +168,12 @@
     <% end %>
 
     <div class="form-control">
-      <%= f.label :review, t('posts.new.review'), class: "label p-2 text-neutral" %>
-      <%= f.text_area :review, rows: 4, class: "textarea textarea-bordered w-full", placeholder: "この商品をどう思いますか？(任意)" %>     
+      <%= f.label :review, t('activerecord.attributes.post.review'), class: "label p-2 text-neutral" %>
+      <%= f.text_area :review, rows: 4, class: "textarea textarea-bordered w-full", placeholder: t('posts.form.post_placeholders') %>     
     </div>
 
     <div class="form-control p-6">
-      <%= f.submit f.object.new_record? ? "投稿する" : "更新する",
+      <%= f.submit f.object.new_record? ? t('helpers.submit.post') : t('helpers.submit.update'),
             class: "bg-primary button-primary" %>
     </div>
   <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -56,10 +56,10 @@
       <% if user_signed_in? && current_user.own?(post) %>
         <div class="flex justify-end gap-4 mt-4 md:mt-0">
           <%= link_to edit_post_path(post), class: "text-sm ring-accent action-button", data: { turbo: false } do %>
-            編集
+            <%= t('helpers.submit.edit') %>
           <% end %>
           <%= link_to post_path(post), class: "text-sm ring-secondary action-button", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
-            削除
+            <%= t('helpers.submit.delete') %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -11,12 +11,11 @@
         placeholder: t('defaults.search_word'),
         data: { search_clear_target: "input" } %>
 
-        <%= f.submit t('defaults.search'),
-          class: "ring-secondary search-form-button text-base" %>
+        <%= f.submit t('helpers.submit.search'), class: "ring-secondary search-form-button text-base" %>
 
         <button type="button" onclick="location.href='<%= url_for(only_path: true) %>'"
           class="ring-[var(--color-base-400)] search-form-button text-base whitespace-nowrap">
-          <%= t('defaults.clear') %>
+          <%= t('helpers.submit.clear') %>
         </button>
     </div>
 
@@ -41,7 +40,6 @@
                   class: "select w-full text-sm bg-white",
                   data: { search_clear_target: "select" } %>
           </div>
-
         </div>
 
         <!-- あまピタ度 -->

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -17,10 +17,10 @@
 
       <div class="flex flex-col justify-start items-start gap-2 md:gap-5 text-neutral py-4 md:px-0 md:py-6">
         <div class="text-sm md:text-base text-base-300">
-          <%= t('.manufacturer') %>：<%= @product.manufacturer %>
+          <%= t('activerecord.attributes.product.manufacturer') %>：<%= @product.manufacturer %>
         </div>
         <div class="text-sm md:text-base text-base-300">
-          <%= t('.category') %>：<%= @product.category.name %>
+          <%= t('activerecord.attributes.product.category_id') %>：<%= @product.category.name %>
         </div>
 
         <!-- あまピタ人数のカウント -->

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -7,99 +7,72 @@ ja:
       sweetness_type: 甘さタイプ
       product: 商品
     attributes:
+      sweetness_strength: 甘みの強さ
+      aftertaste_clarity: 後味のキレ/スッキリ感
+      natural_sweetness: 自然な甘さ
+      coolness: 爽快感
+      richness: 甘さの深み/コク
+      created_at: 作成日時
+      updated_at: 更新日時
       user:
-        current_password: "現在のパスワード"
-        email: "メールアドレス"
-        password: "パスワード"
-        password_confirmation: "確認用パスワード"
-        remember_me: "ログイン情報を記憶する"
+        current_password: 現在のパスワード
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: 確認用パスワード
+        remember_me: ログイン情報を記憶する
       post:
         sweetness_rating: あまピタ度
-        image: 画像
         review: レビュー
-      category:
-        name: "カテゴリ名"
+        post_sweetness_score: あまさ評価
+        image: 商品の画像
       product:
         name: 商品名
+        image: 商品の画像
+        category_id: カテゴリ
         manufacturer: メーカー
-        category: カテゴリ
-        image: 画像
-    errors:
-      models:
-        post:
-          attributes:
-            category_id:
-              blank: "を入力してください"
-              required: "を入力してください"
-            product_name:
-              blank: "を入力してください"
-            manufacturer:
-              blank: "を入力してください"
-            sweetness_rating:
-              blank: "を入力してください"
-      messages:
-        blank: "を入力してください"
-        required: "を入力してください"
-        too_long: "は%{count}文字以内で入力してください"
-        taken: "が登録できませんでした。入力内容をご確認ください"
-        too_short: "は%{count}文字以上で入力してください"
-        confirmation: "と一致しません"
-  attributes:
-    id: ID
-    created_at: 作成日時
-    updated_at: 更新日時
-  errors:
-    format: "%{attribute}%{message}"
-    messages:
-      blank: "を入力してください"
-      required: "を入力してください"
-      too_long: "は%{count}文字以内で入力してください"
-      taken: "が登録できませんでした。入力内容をご確認ください"
-      too_short: "は%{count}文字以上で入力してください"
-      confirmation: "と一致しません"
   enums:
     sweetness_type:
       sweetness_kind:
-        fresh_natural: "さっぱり自然派"
-        rich_romantic: "濃厚ロマン派"
-        sweet_dreamer: "甘党ドリーマー"
-        balance_seeker: "バランス探求派"
+        fresh_natural: さっぱり自然派
+        rich_romantic: 濃厚ロマン派
+        sweet_dreamer: 甘党ドリーマー
+        balance_seeker: バランス探求派
     post:
       sweetness_rating:
         lack_of_sweetness: "あまさが\n足りない"
         could_be_sweeter: "もう少し\n甘さがほしい"
-        perfect_sweetness: "あまピタ！"
+        perfect_sweetness: あまピタ！
         slightly_too_sweet: "少し\nあますぎ"
-        too_sweet: "あますぎ"
+        too_sweet: あますぎ
   datetime:
     distance_in_words:
       less_than_x_seconds:
-        one:   1秒
+        one: 1秒
         other: "%{count}秒"
       x_seconds:
-        one:   1秒
+        one: 1秒
         other: "%{count}秒"
       less_than_x_minutes:
-        one:   1分
+        one: 1分
         other: "%{count}分"
       x_minutes:
-        one:   1分
+        one: 1分
         other: "%{count}分"
       about_x_hours:
-        one:   1時間
+        one: 1時間
         other: "%{count}時間"
       x_days:
-        one:   1日
+        one: 1日
         other: "%{count}日"
       about_x_months:
-        one:   1ヶ月
-        other: 約%{count}ヶ月
+        one: 1ヶ月
+        other: "%{count}ヶ月"
       x_months:
-        one:   1ヶ月
+        one: 1ヶ月
         other: "%{count}ヶ月"
       about_x_years:
-        one:   1年
-        other: 約%{count}年
+        one: 1年
+        other: "%{count}年"
       over_x_years:
-        one:   1年以上
+        one: 1年以上
         other: "%{count}年以上"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,8 +1,6 @@
 ja:
   defaults:
-    search: 検索
-    clear: クリア
-    delete_confirm: "削除しますか？"
+    delete_confirm: 削除しますか？
     search_word: キーワードを入力
     flash_message:
       created: "%{item}を作成しました"
@@ -10,6 +8,26 @@ ja:
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新出来ませんでした"
       deleted: "%{item}を削除しました"
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      blank: "を入力してください"
+      required: "を入力してください"
+      select: "を選んでください"
+      too_long: "は%{count}文字以内で入力してください"
+      taken: が登録できませんでした。入力内容をご確認ください
+      too_short: "は%{count}文字以上で入力してください"
+      confirmation: と一致しません
+  helpers:
+    submit:
+      create: 登録
+      submit: 保存
+      update: 更新する
+      edit: 編集
+      delete: 削除
+      search: 検索
+      clear: クリア
+      post: 投稿する
   diagnoses:
     new:
       title: 甘さ感覚診断
@@ -22,25 +40,15 @@ ja:
   posts:
     new:
       title: あまピタ評価の登録
-      sweetness_rating: あまピタ度
-      post_sweetness_score: あまさ評価
-      review: レビュー
-      image: 商品画像
-      product: 商品
-      product_image: 商品画像
-      manufacturer: メーカー
-      category: カテゴリ
     edit:
       title: あまピタ評価の編集
+    form:
+      post_placeholders: "この商品をどう思いますか？(任意)"
+    select:
+      manufacturer: メーカーを選択
+      category: カテゴリを選択
   products:
     title: 商品の登録
-    image: 商品の画像
-    name: 商品名
-    manufacturer: メーカー
-    category: カテゴリ
-    show:
-      manufacturer: メーカー
-      category: カテゴリ
     manufacturers:
       list:
         - 明治
@@ -58,18 +66,18 @@ ja:
         - ゴンチャ
         - その他
   categories:
-    gummy: "グミ"
-    jelly: "ゼリー"
-    cookie: "クッキー"
-    biscuit: "ビスケット"
-    chocolate: "チョコレート菓子"
-    ice_cream: "アイス"
-    cake: "ケーキ"
-    doughnut: "ドーナツ"
-    bread: "パン"
-    drink: "ドリンク"
-    snack: "スナック菓子"
-    others: "その他"
+    gummy: グミ
+    jelly: ゼリー
+    cookie: クッキー
+    biscuit: ビスケット
+    chocolate: チョコレート菓子
+    ice_cream: アイス
+    cake: ケーキ
+    doughnut: ドーナツ
+    bread: パン
+    drink: ドリンク
+    snack: スナック菓子
+    others: その他
     index:
       title: あまピタ評価する商品を検索
     show:


### PR DESCRIPTION
## 概要
Post/Product関連のバリデーションやビュー、I18nを整理・改善しました。

---

### 🔧 主な変更点

### モデルバリデーション
- Product: `name`, `manufacturer`, `category_id` に `presence` + カスタムメッセージ (`:select`) を設定
- Post: `sweetness_rating` に `presence` + カスタムメッセージ (`:select`) を設定

### フォームビュー修正
-  入力必須マーク(*) を追加
- select の prompt を I18n化

### 商品詳細画面修正
- `products/show.html.erb` のラベル表示を I18n化

### I18n ファイル整理
- `config/locales/activerecord/ja.yml` にモデル名・属性名・enum をまとめる
- 不要になった `views/ja.yml` を削除し、views ディレクトリに分割

🎨 その他：UIの修正

### ✅ 確認事項
- [x] 正しくi18nが翻訳され表示されること
- [x] 既存レイアウト崩れの確認

close #143 