### PR TITLE
Feat/#18 profile edit

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -66,12 +66,16 @@
 @apply px-4 py-2 text-neutral ring-4 rounded-full transition duration-200 bg-base-100 hover:brightness-96;
 }
 
+.action-button-primary {
+@apply px-4 md:px-5 py-3 md:py-4 text-base-100 rounded-full transition duration-200;
+}
+
 .sliders-title {
 @apply px-4 py-2 text-neutral ring-4 rounded-full transition duration-200 bg-base-100;
 }
 
 .sliders-button {
-@apply px-4 md:px-5 py-3 md:py-4 text-base-100 rounded-full transition duration-200 hover:brightness-96 inline-block
+@apply px-4 md:px-5 py-3 md:py-4 text-base-100 rounded-full transition duration-200 hover:brightness-96 inline-block;
 }
 
 .swiper-button-next::after, .swiper-button-prev::after {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  before_action :authenticate_user!, only: [ :new, :create ]
+  before_action :authenticate_user!, only: %i[new create]
 
   def index
     @q = Post.ransack(params[:q])

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,33 @@
+class ProfilesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_user
+
+  def edit
+    @google_user = current_user.provider == "google_oauth2"
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to profile_path(@user), notice: t("defaults.flash_message.updated", item: t("profiles.info"))
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_updated", item: t("profiles.info"))
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    @sweetness_type =  @user.sweetness_type
+    @sweetness_profiles = @user.sweetness_profiles.last
+    @posts = @user.posts.all.order(created_at: :desc)
+  end
+
+  private
+
+  def set_user
+    @user = current_user
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :self_introduction)
+  end
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,3 @@
 class StaticPagesController < ApplicationController
-  def top
-  end
+  def top;end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,8 @@
+class UsersController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+    @posts = @user.posts.order(created_at: :desc)
+    @sweetness_type = @user.sweetness_type
+    @sweetness_profiles = @user.sweetness_profiles.last
+  end
+end

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,0 +1,2 @@
+module ProfilesHelper
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,6 @@
 class Category < ApplicationRecord
+  validates :slug, presence: true, uniqueness: true
+
   has_many :posts, through: :products
   has_many :products
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,11 @@
 class User < ApplicationRecord
-  belongs_to :current_sweetness_type, class_name: "SweetnessType", foreign_key: "sweetness_type_id", optional: true
+  belongs_to :sweetness_type, optional: true
   has_many :sweetness_profiles, dependent: :destroy
   has_many :posts
 
   validates :name, presence: true, length: { maximum: 10 }, uniqueness: true
   validates :uid, presence: true, uniqueness: { scope: :provider }
+  validates :self_introduction, length: { maximum: 100 }
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,

--- a/app/views/diagnoses/show.html.erb
+++ b/app/views/diagnoses/show.html.erb
@@ -19,7 +19,7 @@
     <div class="flex justify-center p-4">
         <div class="w-full max-w-md">
         <div class="p-4 border-secondary rounded-3xl bg-base-100">
-            <%= render "shared/chart",
+            <%= render "shared/chart/sweetness_profile_chart",
             chart_id: "radarChart",
             data: [
                 @profile.sweetness_strength,

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -42,12 +42,14 @@
     <!-- 既存商品の場合 -->
     <% if @post.product.persisted? %>
       <%= f.hidden_field :product_id, value: @post.product.id %>
-      <div class="bg-base-100 p-4 rounded-4xl text-sm text-neutral">
-      <span class="text-left inline-block leading-loose">
-        <p><%=t('activerecord.attributes.product.name') %>：<%= @post.product.name %></p>
-        <p><%=t('activerecord.attributes.product.manufacturer') %>：<%= @post.product.manufacturer %></p>
-        <p><%=t('activerecord.attributes.product.category_id') %>：<%= @post.product.category.name %></p>
-      </span>
+      <div class="flex justify-center w-full">
+        <div class="bg-base-100 p-4 rounded-4xl text-sm text-neutral w-fit ring-primary ring-2">
+        <span class="text-left inline-block leading-loose">
+          <p><%=t('activerecord.attributes.product.name') %>：<%= @post.product.name %></p>
+          <p><%=t('activerecord.attributes.product.manufacturer') %>：<%= @post.product.manufacturer %></p>
+          <p><%=t('activerecord.attributes.product.category_id') %>：<%= @post.product.category.name %></p>
+        </span>
+        </div>
       </div>
     <% else %>
 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -17,12 +17,17 @@
     <div class="card-body flex-1 min-w-0 flex py-2 flex-col text-neutral justify-between">
       <div class="flex-1">
         <p class="text-sm mb-2">
-          <%= post.user.name %> ｜ <%= time_ago_in_words(post.created_at) %>前
+          <%= link_to user_path(post.user), class: "flex items-center gap-1 hover:opacity-70" do %>
+            <span><%= post.user.name %></span>
+            <span>｜</span>
+            <span><%= time_ago_in_words(post.created_at) %>前</span>
+          <% end %>
         </p>
+
         <%= link_to post_path(post) do %>
         <div class="flex items-center justify-between py-1 text-base-300"><%= post.product.manufacturer %></div>
           <div class="flex items-center justify-between mb-3">
-            <div class="card-title text-md md:text-lg line-clamp-2"><%= post.product.name %></div>
+            <div class="card-title text-md md:text-lg line-clamp-2 hover:opacity-70"><%= post.product.name %></div>
           </div>
         <% end %>
         <p class="text-sm"><%= truncate(post.review, length: 25, omission: '...') %></p>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,7 +1,6 @@
 <div class="p-2 md:p-4">
   <div class="flex flex-col p-2 md:p-4 items-center justify-center w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
     <h1 class="text-center text-xl md:text-2xl p-4 border-b border-gray-300 w-full leading-relaxed">
-     「<%= @post.product.name %>」<br>
       <%= t('.title') %></h1>
    <%= render 'form', post: @post %>
   </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -20,10 +20,10 @@
         </div>
         
         <div class="flex flex-col text-base">
-          <div class="flex items-center gap-2">
+          <%= link_to user_path(@post.user), class: "flex items-center gap-2 hover:opacity-70" do %>
             <%= image_tag "footer/user_circle.svg", class: "h-10 w-10" %>
             <span class="font-medium"><%= @post.user.name %></span>
-          </div>
+          <% end %>
         </div>
 
         <!-- 評価部分 -->
@@ -68,7 +68,7 @@
     <div class="flex justify-center p-2">
       <div class="w-full max-w-lg sm:max-w-xl lg:max-w-xl p-2 border-secondary rounded-3xl bg-base-100">
         <div class="mx-auto w-full max-w-md">
-          <%= render "shared/chart",
+          <%= render "shared/chart/sweetness_posts",
               chart_id: "radarChart",
               data: [
                   @post.post_sweetness_score.sweetness_strength,

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -53,7 +53,7 @@
       <div class="w-full max-w-lg sm:max-w-xl lg:max-w-xl p-2 border-secondary rounded-3xl bg-base-100">
         <div class="mx-auto w-full max-w-md p-2">
         <% if user_signed_in? && @user_post.present? %>
-            <%= render "shared/average_chart",
+            <%= render "shared/chart/sweetness_average",
             chart_id: "averageChart",
             user_data: [
                 @user_post.post_sweetness_score.sweetness_strength,
@@ -70,7 +70,7 @@
                 @average_scores[:richness]
             ] %>
         <% else %>
-            <%= render "shared/chart",
+            <%= render "shared/chart/sweetness_posts",
             chart_id: "radarChart",
             data: [
                 @average_scores[:sweetness_strength],
@@ -155,7 +155,7 @@
             <%= link_to new_post_path(product_id: @product.id), class: "bg-primary rounded-full px-4 py-3 inline-flex items-center gap-3 shadow-sm hover-animation" do %>
               <%= image_tag "smiley-wink.svg", class: "h-9 w-9 md:h-10 md:w-10 flex-shrink-0" %>
               <span class="text-sm md:text-base">
-                <%= t('defaults.new_post') %>
+                <%= t('defaults.buttons.new_post') %>
               </span>
             <% end %>
           </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,67 @@
+<div class="p-1 md:p-4">
+  <div class="flex flex-col p-2 md:p-6 items-center justify-center w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
+    <h1 class="text-center text-xl md:text-2xl p-4 border-b border-gray-300 w-full">
+      <%= t('.title') %>
+    </h1>
+  
+    <%= form_with model: @user, url: profile_path, method: :put do |f| %>
+      <% if @user.errors.any? %>
+        <div class="error-messages text-error bg-base-100 p-2 md:p-4 rounded-4xl ring-2 ring-error">
+          <ul>
+            <% @user.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <!-- ユーザー情報 -->
+      <div class="p-6">
+        <div class="mb-3 md:mb-6 w-full">
+          <%= f.label :name, class: "form-label" %>
+          <%= f.text_field :name, class: "input input-bordered w-full" %>
+        </div>
+
+        <% if @google_user %>
+          <div class="mb-3 md:mb-6 w-full">
+            <%= t('activerecord.attributes.user.email') %>
+            <div class="border-2 border-[var(--color-base-400)] rounded-2xl w-full bg-base-200 py-2 px-3 text-sm">
+              <%= @user.email %>
+            </div>
+            <div class="mt-4">
+              <label class="form-label"><%=t('.authentication') %></label>
+            </div>
+            <div class="inline-flex items-center border-2 border-[var(--color-base-400)]
+                        bg-white text-bg-neutral rounded-2xl p-3 w-auto">
+              <img src="https://developers.google.com/identity/images/g-logo.png"
+                  alt="Google Logo" class="h-5 mr-2" />
+              <span class="font-roboto text-sm"><%= t('.google') %></span>
+              <span class="px-2 text-xs">
+                <span class="font-roboto bg-accent px-3 py-1 rounded-xl">
+                  <%= t('.google_user') %>
+                </span>
+              </span>
+            </div>
+          </div>
+        <% else %>
+          <div class="mb-3 md:mb-6 w-full">
+            <%= f.label :email, class: "form-label" %>
+            <%= f.email_field :email, class: "input input-bordered w-full" %>
+          </div>
+        <% end %>
+
+        <div class="mb-3 md:mb-6 w-full">
+          <%= f.label :self_introduction, class: "form-label" %>
+          <%= f.text_area :self_introduction, class: "textarea textarea-bordered w-full", rows: 5 %>
+        </div>
+
+        <!-- 更新 -->
+        <div class="flex flex-col gap-4 p-4 md:p-6 w-full">
+          <div class="flex justify-center w-full">
+            <%= f.submit t('helpers.submit.update'), class: "text-sm md:text-base ring-secondary action-button" %>
+          </div>
+        </div>
+      </div> 
+    <% end %>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,7 @@
+<%= render "shared/user_profile",
+    user: @user,
+    sweetness_type: @sweetness_type,
+    sweetness_profiles: @sweetness_profiles,
+    posts: @posts,
+    chart_id: "radarChart",
+    show_edit_button: true %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -24,7 +24,7 @@
       </span>
     <% end %>
 
-    <%= link_to "#", class: "flex flex-col items-center justify-center leading-none opacity-60" do %>
+    <%= link_to profile_path, class: "flex flex-col items-center justify-center leading-none" do %>
       <span class="p-2 rounded-full">
       <%= image_tag "footer/user_circle.svg", class: "h-8 w-8 md:h-9 md:w-9" %>
       </span>

--- a/app/views/shared/_user_profile.html.erb
+++ b/app/views/shared/_user_profile.html.erb
@@ -41,7 +41,7 @@
 
           <div class="flex justify-end text-sm md:text-base font-bold mb-2">
             <span class="rounded-full bg-secondary text-white px-3 py-2 text-sm md:text-base">
-              <%= I18n.t("enums.sweetness_type.sweetness_kind.#{@sweetness_type.sweetness_kind}") %>
+              <%= I18n.t("enums.sweetness_type.sweetness_kind.#{sweetness_type.sweetness_kind}") %>
             </span>
           </div>
 

--- a/app/views/shared/_user_profile.html.erb
+++ b/app/views/shared/_user_profile.html.erb
@@ -1,0 +1,114 @@
+<div class="p-1 md:p-4">
+  <div class="flex flex-col p-2 md:p-6 items-center justify-center w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
+    <h1 class="text-center text-xl md:text-2xl p-4 border-b border-gray-300 w-full">
+      <% if user == current_user %>
+        <%= t('profiles.show.title') %>
+      <% else %>
+        <%= t('profiles.info') %>
+      <% end %>
+    </h1>
+
+    <!-- ユーザー情報 -->
+    <div class="flex flex-col justify-center items-center sm:items-start gap-4">
+      <div class="flex flex-row gap-2 md:gap-6 pt-6">
+        <div class="text-base md:text-xl">
+          <%= user.name %>
+        </div>
+      </div>
+
+      <% if user.self_introduction.present? %>
+        <div class="flex flex-col rounded-xl py-2 md:py-3 text-sm">
+          <span><%= user.self_introduction %></span>
+        </div>
+      <% end %>
+
+      <!-- 編集 -->
+      <% if user == current_user %>
+        <div class="flex flex-col gap-4 p-1 md:p-2 w-full">
+          <div class="flex justify-end w-full">
+            <%= link_to edit_profile_path, class: "text-sm ring-accent action-button", data: { turbo: false } do %>
+              <%= t('helpers.submit.edit') %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+    <!-- チャート -->
+    <% if sweetness_profiles.present? %>
+      <div class="flex justify-center p-2 w-full">
+        <div class="w-full max-w-lg md:max-w-xl p-2 rounded-3xl bg-base-100">
+
+          <div class="flex justify-end text-sm md:text-base font-bold mb-2">
+            <span class="rounded-full bg-secondary text-white px-3 py-2 text-sm md:text-base">
+              <%= I18n.t("enums.sweetness_type.sweetness_kind.#{@sweetness_type.sweetness_kind}") %>
+            </span>
+          </div>
+
+          <div class="mx-auto w-full max-w-md">
+            <%= render "shared/chart/sweetness_profile_chart",
+                chart_id: chart_id,
+                data: [
+                  sweetness_profiles.sweetness_strength,
+                  sweetness_profiles.aftertaste_clarity,
+                  sweetness_profiles.natural_sweetness,
+                  sweetness_profiles.coolness,
+                  sweetness_profiles.richness,
+                ] %>
+          </div>
+
+          <div class="flex justify-end text-xs md:text-sm pb-4 text-gray-300">
+            <%= t('profiles.diagnosis.latest_date') %>：
+            <%= l sweetness_profiles.created_at %>
+          </div>
+
+          <% if user == current_user %>
+            <div class="flex justify-end">
+              <%= link_to new_diagnosis_path, class: "text-sm bg-primary action-button-primary hover-animation", data: { turbo: false } do %>
+                <%= t('defaults.buttons.retake_diagnosis') %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% else %>
+      <% if user == current_user %>
+        <div class="text-center py-6 text-sm md:text-base text-[var(--color-base-400)]">
+          <%= raw t('profiles.diagnosis.no_data') %>
+        </div>
+        <div class="flex justify-end">
+          <%= link_to new_diagnosis_path, class: "text-sm bg-primary action-button-primary hover-animation", data: { turbo: false } do %>
+            <%= t('defaults.buttons.take_diagnosis') %>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+
+    <!-- タブ -->
+    <div class="tabs tabs-border py-2 md:py-6 justify-center w-full">
+      <!-- 投稿 -->
+      <input type="radio" name="my_tabs_4" role="tab"
+        class="tab text-xs md:text-base text-primary hover:text-primary"
+        aria-label="<%= t('profiles.tabs.posts') %>" checked />
+      <div role="tabpanel" class="tab-content bg-base-100 md:p-6 border-primary rounded-4xl w-full">
+        <div class="flex flex-col mx-auto items-center justify-center text-xs md:text-sm w-full">
+          <% if @posts.present? %>
+            <%= render @posts %>
+          <% else %>
+            <p class="p-4"><%= t('profiles.empty_states.no_posts') %></p>
+          <% end %>
+        </div>
+      </div>
+
+      <!-- ブックマーク -->
+      <input type="radio" name="my_tabs_4" role="tab"
+        class="tab text-xs md:text-base text-accent hover:text-accent"
+        aria-label="<%= t('profiles.tabs.bookmarks') %>" />
+      <div role="tabpanel" class="tab-content bg-base-100 md:p-6 border-accent rounded-4xl w-full">
+        <div class="flex flex-col mx-auto items-center justify-center text-xs md:text-sm w-full">
+          <p class="p-4"><%= t('profiles.empty_states.no_bookmarks') %></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/chart/_sweetness_average.html.erb
+++ b/app/views/shared/chart/_sweetness_average.html.erb
@@ -18,7 +18,7 @@
         labels: ["甘みの強さ", ["後味のキレ/","スッキリ感"], "自然な甘さ", "爽快感", "甘さの深み/コク"],
         datasets: [
           {
-            label: "あなたの評価",
+            label: ["<%= t('defaults.chart.sweetness_user') %>"],
             data: [<%= user_data.map(&:to_i).join(", ") %>],
             backgroundColor: 'rgba(245, 182, 199, 0.4)',
             borderColor: 'rgba(245, 182, 199, 0.6)',
@@ -26,7 +26,7 @@
             pointBackgroundColor: 'rgba(245, 182, 199, 0.6)'
           },
           {
-            label: "みんなの評価",
+            label: ["<%= t('defaults.chart.sweetness_average') %>"],
             data: [<%= average_data.map(&:to_i).join(", ") %>],
             backgroundColor: 'rgba(153, 215, 170, 0.4)',
             borderColor: 'rgba(153, 215, 170, 0.6)',

--- a/app/views/shared/chart/_sweetness_posts.html.erb
+++ b/app/views/shared/chart/_sweetness_posts.html.erb
@@ -8,14 +8,14 @@
     if (Chart.getChart(ctx)) {
       Chart.getChart(ctx).destroy();
     }
-      // 画面幅でborderWidthを切り替え
+
     const borderWidth = window.innerWidth < 768 ? 2 : 4;
     new Chart(ctx, {
       type: 'radar',
       data: {
         labels: ["甘みの強さ", ["後味のキレ/","スッキリ感"], "自然な甘さ", "爽快感", "甘さの深み/コク"],
         datasets: [{
-          label: "甘さの感覚",
+          label: ["<%= t('defaults.chart.sweetness_user') %>"],
           data: [<%= data.map(&:to_i).join(", ") %>],
           backgroundColor: 'rgba(245, 182, 199, 0.4)',
           borderColor: 'rgba(245, 182, 199, 0.6)',

--- a/app/views/shared/chart/_sweetness_profile_chart.html.erb
+++ b/app/views/shared/chart/_sweetness_profile_chart.html.erb
@@ -1,0 +1,40 @@
+<canvas id="radarChart" width="400" height="400"></canvas>
+
+<script>
+  document.addEventListener("turbo:load", function () {
+    const ctx = document.getElementById("radarChart");
+    if (!ctx) return;
+
+    if (Chart.getChart(ctx)) {
+      Chart.getChart(ctx).destroy();
+    }
+
+    const borderWidth = window.innerWidth < 768 ? 2 : 4;
+    new Chart(ctx, {
+      type: 'radar',
+      data: {
+        labels: ["甘みの強さ", ["後味のキレ/","スッキリ感"], "自然な甘さ", "爽快感", "甘さの深み/コク"],
+        datasets: [{
+          label: ["<%= t('defaults.chart.sweetness_profile') %>"],
+          data: [<%= data.map(&:to_i).join(", ") %>],
+          backgroundColor: 'rgba(144, 173, 220, 0.4)',
+          borderColor: 'rgba(144, 173, 220, 0.6)',
+          borderWidth: borderWidth,
+          pointBackgroundColor: 'rgba(144, 173, 220, 0.6)'
+        }]
+      },
+      options: {
+        responsive: true,
+        scales: {
+          r: {
+            min: 0,
+            max: 5,
+            ticks: {
+              stepSize: 1
+            }
+          }
+        }
+      }
+    });
+  });
+</script>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,7 @@
+<%= render "shared/user_profile",
+    user: @user,
+    sweetness_type: @sweetness_type,
+    sweetness_profiles: @sweetness_profiles,
+    posts: @posts,
+    chart_id: "radarChart",
+    show_edit_button: false %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -15,11 +15,13 @@ ja:
       created_at: 作成日時
       updated_at: 更新日時
       user:
+        self_introduction: ひとこと
         current_password: 現在のパスワード
         email: メールアドレス
         password: パスワード
         password_confirmation: 確認用パスワード
         remember_me: ログイン情報を記憶する
+      profile: ユーザー情報
       post:
         sweetness_rating: あまピタ度
         review: レビュー

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -10,14 +10,17 @@ ja:
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新出来ませんでした"
       deleted: "%{item}を削除しました"
-    messages:
-      
-      
     label:
       stats: "%{count}人中%{perfect}人があまピタッ！"
       no_rating: あまピタ評価はまだありません
     buttons:
       new_post: あまピタ評価をする
+      retake_diagnosis: もう一度診断する
+      take_diagnosis: 甘さ感覚診断をする
+    chart:
+      sweetness_profile: 好みの甘さ感覚
+      sweetness_user: あなたの評価
+      sweetness_average: みんなの評価
   errors:
     format: "%{attribute}%{message}"
     messages:
@@ -38,6 +41,24 @@ ja:
       search: 検索
       clear: クリア
       post: 投稿する
+  profiles:
+    info: ユーザー情報
+    tabs:
+      posts: 投稿した甘さ評価
+      bookmarks: 保存した商品
+    empty_states:
+      no_posts: 投稿した甘さ評価はありません
+      no_bookmarks: 保存した商品はありません
+    show:
+      title: マイページ
+    diagnosis:
+      latest_date: 最終診断日
+      no_data: 甘さ感覚診断を行うと、<br>好みの甘さ感覚チャートが表示されます。
+    edit:
+      title: プロフィール編集
+      authentication: 外部アカウント連携
+      google: Googleアカウント
+      google_user: 連携済
   diagnoses:
     new:
       title: 甘さ感覚診断

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,20 +7,21 @@ Rails.application.routes.draw do
 
   root "static_pages#top"
 
-  resources :diagnoses, only: [ :new, :create ]
+  resource :profile, only: %i[edit show update]
+
+  resources :users, only: %i[show]
+
+  resources :diagnoses, only: %i[new create]
   get "diagnoses/result/:token", to: "diagnoses#show", as: :diagnosis_result
 
-  resources :posts, only: [ :index, :new, :create, :edit, :show, :update, :destroy ]
-  resources :products, only: [ :index, :show ]
+  resources :posts, only: %i[index show new create edit update destroy]
 
-  resources :categories, only: [ :index, :show ], param: :slug do
-    resources :products, only: [ :show ]
+  resources :products, only: %i[index show]
+  resources :categories, only: %i[index show], param: :slug do
+    resources :products, only: %i[show]
   end
 
-  resources :products, only: [ :show ]
-
   get "up" => "rails/health#show", as: :rails_health_check
-
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 end

--- a/db/migrate/20250904022607_change_slug_not_null_on_categories.rb
+++ b/db/migrate/20250904022607_change_slug_not_null_on_categories.rb
@@ -1,0 +1,5 @@
+class ChangeSlugNotNullOnCategories < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :categories, :slug, false
+  end
+end

--- a/db/migrate/20250904031055_add_self_introduction_to_users.rb
+++ b/db/migrate/20250904031055_add_self_introduction_to_users.rb
@@ -1,0 +1,5 @@
+class AddSelfIntroductionToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :self_introduction, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_03_024149) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_04_031055) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,7 +46,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_03_024149) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "slug"
+    t.string "slug", null: false
     t.index ["slug"], name: "index_categories_on_slug", unique: true
   end
 
@@ -117,6 +117,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_03_024149) do
     t.string "provider"
     t.string "uid"
     t.bigint "sweetness_type_id"
+    t.string "self_introduction"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["sweetness_type_id"], name: "index_users_on_sweetness_type_id"

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class CategoriesControllerTest < ActionDispatch::IntegrationTest
   def setup
-    @category = Category.create!(name: "Cake", slug: "cake")
+    @category = Category.create!(name: "Cookie", slug: "cookie")
   end
 
   test "should get index" do
@@ -11,7 +11,7 @@ class CategoriesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get show" do
-    get category_path(@category)
+    get category_path(@category.slug)
     assert_response :success
   end
 end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class ProfilesControllerTest < ActionDispatch::IntegrationTest
+  test "should get edit" do
+    get profile_path
+    assert_response :success
+  end
+
+  test "should get show" do
+    get profile_path
+    assert_response :success
+  end
+end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,8 +1,13 @@
 require "test_helper"
 
 class ProfilesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    sign_in @user
+  end
+
   test "should get edit" do
-    get profile_path
+    get edit_profile_path
     assert_response :success
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,7 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name: String
+  name: Cake
+  slug: "cake"
 
 two:
-  name: MyString
+  name: Bread
+  slug: "bread"

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,9 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
+  id: 1
   name: Cake
   slug: "cake"
 
 two:
+  id: 2
   name: Bread
   slug: "bread"

--- a/test/fixtures/post_sweetness_scores.yml
+++ b/test/fixtures/post_sweetness_scores.yml
@@ -1,7 +1,8 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  post: one
+  id: 1
+  post_id: 1
   sweetness_strength: 1
   aftertaste_clarity: 1
   natural_sweetness: 1
@@ -9,7 +10,8 @@ one:
   richness: 1
 
 two:
-  post: two
+  id: 2
+  post_id: 2
   sweetness_strength: 1
   aftertaste_clarity: 1
   natural_sweetness: 1

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,13 +1,15 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  user: one
-  product: one_product
+  id: 1
+  user_id: 1
+  product_id: 1
   sweetness_rating: 1
   review: MyText
 
 two:
-  user: two
-  product: two_product
+  id: 2
+  user_id: 2
+  product_id: 2
   sweetness_rating: 1
   review: MyText

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -1,12 +1,14 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one_product:
-  category: one
+  id: 1
+  category_id: 1
   name: "MyString"
   manufacturer: "MyString"
 
 two_product:
-  category: two
+  id: 2
+  category_id: 2
   name: "MyString1"
   manufacturer: "MyString"
 

--- a/test/fixtures/sweetness_profiles.yml
+++ b/test/fixtures/sweetness_profiles.yml
@@ -1,9 +1,10 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  user: one
-  token: "1a2b3c4d-5e6f-7g8h-9i0j-k1l2m3n4o5p6"
+  id: 1
+  user_id: 1
   sweetness_type_id: 1
+  token: "1a2b3c4d-5e6f-7g8h-9i0j-k1l2m3n4o5p6"
   sweetness_strength: 1
   aftertaste_clarity: 1
   natural_sweetness: 1
@@ -11,9 +12,10 @@ one:
   richness: 1
 
 two:
-  user: two
+  id: 2
+  user_id: 2
+  sweetness_type_id: 2
   token: "7h8i9j0k-1l2m-3n4o-5p6q-7r8s9t0u1v2w"
-  sweetness_type_id: 1
   sweetness_strength: 1
   aftertaste_clarity: 1
   natural_sweetness: 1

--- a/test/fixtures/sweetness_types.yml
+++ b/test/fixtures/sweetness_types.yml
@@ -2,8 +2,8 @@
 
 one:
   id: 1
-  sweetness_kind: 1
+  sweetness_kind: "さっぱり自然派"
 
 two:
   id: 2
-  sweetness_kind: 1
+  sweetness_kind: "バランス探求派"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -5,7 +5,13 @@
 # below each fixture, per the syntax in the comments below
 #
 one:
+  id: 1
   email: "user1@example.com"
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password123') %>
+  sweetness_type_id: 1
 
 two:
+  id: 2
   email: "user2@example.com"
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password123') %>
+  sweetness_type_id: 2

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ module ActiveSupport
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all
 
-    # Add more helper methods to be used by all tests here...
+    # Devise の Integration テスト用ヘルパーを読み込み
+    include Devise::Test::IntegrationHelpers
   end
 end


### PR DESCRIPTION
## 概要
ユーザーのプロフィール編集機能を実装・修正しました。  
プロフィールページでのユーザー情報の表示・編集・更新が可能になっています。

### 📋 主な変更点
- ProfilesController に `edit` / `update`  / `show`アクションを追加
- フォームは部分テンプレート化し、既存のユーザー情報を表示
- バリデーションエラーの表示
-  Google認証ユーザーの場合はメールアドレス以外編集可能に

### 今後対応予定
- プロフィール画像アップロード機能の追加
- Google認証ユーザーのアバター表示
- ブックマーク機能

### ✅ 確認事項
- [x] プロフィール編集ページに正しいユーザー情報が表示される
- [x] 投稿のユーザー名からユーザー情報へ画面遷移できる
- [x] ユーザー情報画面で対象ユーザーの過去の投稿が表示される
- [x] 最新の診断結果がマイページに表示される
- [x] バリデーションエラー時に適切なエラーメッセージが表示される

close #18 
