### PR TITLE
Feat/#41 avatar setting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,31 +31,26 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
-# Amazon S3
-gem "aws-sdk-s3"
-
-# Active Storage
-gem "image_processing", "~> 1.2"
-
-# Validation
-gem "active_storage_validations"
-
-# tailwindcss
-gem "tailwindcss-rails"
-
-# devise
+# Authentication & Authorization
 gem "devise"
 gem "devise-i18n"
-
-# omniauth
 gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"
 
+# File Upload & Storage
+gem "aws-sdk-s3"
+gem "image_processing", "~> 1.2"
+gem "active_storage_validations"
+
+# Presentation Layer
+gem "draper"
+
+# UI & Frontend
+gem "tailwindcss-rails"
+gem "ransack"
 gem "meta-tags"
 
-# ransack
-gem "ransack"
-
+# Debug & Development Tools
 gem "swimming_fish", "~> 0.2.2"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (7.2.2.1)
       activesupport (= 7.2.2.1)
+    activemodel-serializers-xml (1.0.3)
+      activemodel (>= 5.0.0.a)
+      activesupport (>= 5.0.0.a)
+      builder (~> 3.1)
     activerecord (7.2.2.1)
       activemodel (= 7.2.2.1)
       activesupport (= 7.2.2.1)
@@ -139,6 +143,13 @@ GEM
     dotenv-rails (3.1.8)
       dotenv (= 3.1.8)
       railties (>= 6.1)
+    draper (4.0.4)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
@@ -330,6 +341,8 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.2)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -367,6 +380,7 @@ GEM
     ruby-vips (2.2.4)
       ffi (~> 1.12)
       logger
+    ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
     securerandom (0.4.1)
     selenium-webdriver (4.34.0)
@@ -451,6 +465,7 @@ DEPENDENCIES
   devise
   devise-i18n
   dotenv-rails
+  draper
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails

--- a/app/assets/images/avatar.svg
+++ b/app/assets/images/avatar.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg height="64px" width="64px" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-10.31 -10.31 81.29 81.29" xml:space="preserve" fill="#ffffff" stroke="#ffffff" transform="rotate(0)" stroke-width="0.0006067100000000001">
+<g id="SVGRepo_bgCarrier" stroke-width="0" transform="translate(0,0), scale(1)">
+<rect x="-10.31" y="-10.31" width="81.29" height="81.29" rx="40.645" fill="#d5d2c8" strokewidth="0"/>
+</g>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round" stroke="#CCCCCC" stroke-width="1.82013"/>
+<g id="SVGRepo_iconCarrier"> <g> <g> <ellipse style="fill:#706a61;" cx="30.336" cy="12.097" rx="11.997" ry="12.097"/> <path style="fill:#706a61;" d="M35.64,30.079H25.031c-7.021,0-12.714,5.739-12.714,12.821v17.771h36.037V42.9 C48.354,35.818,42.661,30.079,35.64,30.079z"/> </g> </g> </g>
+</svg>

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
 
   def index
     @q = Post.ransack(params[:q])
-    @posts = @q.result(distinct: true).includes(:user).all.order(created_at: :desc)
+    @posts = @q.result(distinct: true).includes(:user).all.order(created_at: :desc).decorate
   end
 
   def new
@@ -44,7 +44,7 @@ class PostsController < ApplicationController
   end
 
   def show
-    @post = Post.find(params[:id])
+    @post = Post.find(params[:id]).decorate
   end
 
   def destroy

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
   def show
-    @product = Product.find(params[:id])
-    @posts = @product.posts.order(created_at: :desc)
+    @product = Product.find(params[:id]).decorate
+    @posts = @product.decorate.posts.order(created_at: :desc)
     @average_scores = @product.average_sweetness_scores
     @user_post = @posts.find_by(user_id: current_user.id) if user_signed_in?
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,14 +1,13 @@
 class ProfilesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_user
+  before_action :set_google_user, only: %i[edit update]
 
-  def edit
-    @google_user = current_user.provider == "google_oauth2"
-  end
+  def edit;end
 
   def update
     if @user.update(user_params)
-      redirect_to profile_path(@user), notice: t("defaults.flash_message.updated", item: t("profiles.info"))
+      redirect_to profile_path, notice: t("defaults.flash_message.updated", item: t("profiles.info"))
     else
       flash.now[:alert] = t("defaults.flash_message.not_updated", item: t("profiles.info"))
       render :edit, status: :unprocessable_entity
@@ -16,9 +15,10 @@ class ProfilesController < ApplicationController
   end
 
   def show
+    @user = @user.decorate
     @sweetness_type =  @user.sweetness_type
     @sweetness_profiles = @user.sweetness_profiles.last
-    @posts = @user.posts.all.order(created_at: :desc)
+    @posts = @user.posts.all.order(created_at: :desc).decorate
   end
 
   private
@@ -27,7 +27,11 @@ class ProfilesController < ApplicationController
     @user = current_user
   end
 
+  def set_google_user
+    @google_user = current_user&.provider == "google_oauth2"
+  end
+
   def user_params
-    params.require(:user).permit(:name, :email, :self_introduction)
+    params.require(:user).permit(:name, :email, :self_introduction, :avatar)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   def show
-    @user = User.find(params[:id])
-    @posts = @user.posts.order(created_at: :desc)
+    @user = User.find(params[:id]).decorate
+    @posts = @user.posts.order(created_at: :desc).decorate
     @sweetness_type = @user.sweetness_type
     @sweetness_profiles = @user.sweetness_profiles.last
   end

--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -1,0 +1,16 @@
+class PostDecorator < Draper::Decorator
+  delegate_all
+
+  COMMON_VARIANT_OPTIONS = { resize_to_fill: [ 400, 400 ], format: :webp, saver: { quality: 85 } }.freeze
+
+  def post_image(**options)
+    default_classes = "object-cover"
+    custom_classes  = options[:class]
+    merged_classes  = [ default_classes, custom_classes ].compact.join(" ")
+
+    h.image_tag(
+      object.image.attached? ? object.image.variant(COMMON_VARIANT_OPTIONS) : "default_image.png",
+      options.merge(class: merged_classes)
+    )
+  end
+end

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -1,0 +1,16 @@
+class ProductDecorator < Draper::Decorator
+  delegate_all
+
+  COMMON_VARIANT_OPTIONS = { resize_to_fill: [ 400, 400 ], format: :webp, saver: { quality: 85 } }.freeze
+
+  def product_image(**options)
+    default_classes = "object-cover"
+    custom_classes  = options[:class]
+    merged_classes  = [ default_classes, custom_classes ].compact.join(" ")
+
+    h.image_tag(
+      object.image.attached? ? object.image.variant(COMMON_VARIANT_OPTIONS) : "default_image.png",
+      options.merge(class: merged_classes)
+    )
+  end
+end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,0 +1,21 @@
+class UserDecorator < Draper::Decorator
+  delegate_all
+
+  COMMON_VARIANT_OPTIONS = { resize_to_fill: [ 400, 400 ], format: :webp, saver: { quality: 85 } }.freeze
+
+  def avatar_image(**options)
+    default_classes = "rounded-full object-cover"
+    custom_classes  = options[:class]
+    merged_classes  = [ default_classes, custom_classes ].compact.join(" ")
+
+    image_url = if object.avatar.attached?
+      object.avatar.variant(UserDecorator::COMMON_VARIANT_OPTIONS)
+    elsif object.profile_image_url.present?
+      object.profile_image_url
+    else
+      "avatar.svg"
+    end
+
+    h.image_tag(image_url, options.merge(class: merged_classes))
+  end
+end

--- a/app/models/concerns/image_validatable.rb
+++ b/app/models/concerns/image_validatable.rb
@@ -1,0 +1,31 @@
+module ImageValidatable
+  extend ActiveSupport::Concern
+
+  included do
+    validate :image_type_and_size, if: -> { respond_to?(:image) && image.attached? }
+    validate :avatar_type_and_size, if: -> { respond_to?(:avatar) && avatar.attached? }
+  end
+
+  private
+
+  def image_type_and_size
+    validate_attachment(:image)
+  end
+
+  def avatar_type_and_size
+    validate_attachment(:avatar)
+  end
+
+  def validate_attachment(attachment_name)
+    attachment = send(attachment_name)
+    return unless attachment.attached?
+
+    unless attachment.content_type.in?(%w[image/png image/jpg image/jpeg])
+      errors.add(attachment_name, "はJPG・JPEG・PNG形式のファイルのみ対応しています")
+    end
+
+    if attachment.blob.byte_size > 5.megabytes
+      errors.add(attachment_name, "は5MB以下にしてください")
+    end
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,16 +1,17 @@
 class Post < ApplicationRecord
+  include ImageValidatable
+  has_one_attached :image
+
   validates :sweetness_rating, presence: { message: :select }
   validates :post_sweetness_score, presence: true
-  validate :image_type_and_size
   validates :review, length: { maximum: 500 }
 
   belongs_to :user
   belongs_to :product
   has_one :category, through: :product
-  accepts_nested_attributes_for :product, update_only: true
-
-  has_one_attached :image
   has_one :post_sweetness_score, dependent: :destroy
+
+  accepts_nested_attributes_for :product, update_only: true
   accepts_nested_attributes_for :post_sweetness_score
 
   enum :sweetness_rating, {
@@ -27,19 +28,5 @@ class Post < ApplicationRecord
 
   def self.ransackable_associations(auth_object = nil)
     [ "product", "user", "category" ]
-  end
-
-  private
-
-  def image_type_and_size
-    return unless image.attached?
-
-    unless image.content_type.in?(%w[image/png image/jpg image/jpeg])
-      errors.add(:image, "はJPG・JPEG・PNG形式のファイルのみ対応しています")
-    end
-
-    if image.blob.byte_size > 5.megabytes
-      errors.add(:image, "は5MB以下にしてください")
-    end
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,7 @@
 class Product < ApplicationRecord
+  include ImageValidatable
+  has_one_attached :image
+
   validates :name, presence: true, length: { maximum: 40 }
   validates :manufacturer, presence: { message: :select }
   validates :name, uniqueness: { scope: :manufacturer, message: "とメーカーの組み合わせは既に存在します" }
@@ -6,7 +9,6 @@ class Product < ApplicationRecord
 
   belongs_to :category, optional: true
   has_many :posts, dependent: :destroy
-  has_one_attached :image
 
   def total_posts
     posts.size

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,15 +1,21 @@
-class User < ApplicationRecord
-  belongs_to :sweetness_type, optional: true
-  has_many :sweetness_profiles, dependent: :destroy
-  has_many :posts
+require "open-uri"
 
-  validates :name, presence: true, length: { maximum: 10 }, uniqueness: true
+class User < ApplicationRecord
+  include ImageValidatable
+
+  devise :database_authenticatable, :registerable,
+        :recoverable, :rememberable, :validatable,
+        :omniauthable, omniauth_providers: [ :google_oauth2 ]
+
+  has_one_attached :avatar
+
+  validates :name, presence: true, length: { maximum: 20 }, uniqueness: true
   validates :uid, presence: true, uniqueness: { scope: :provider }
   validates :self_introduction, length: { maximum: 100 }
 
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: [ :google_oauth2 ]
+  belongs_to :sweetness_type, optional: true
+  has_many :sweetness_profiles, dependent: :destroy
+  has_many :posts
 
   # providerとuidを使ってユーザーを検索、存在しなければ新規作成
   def self.from_omniauth(auth)
@@ -17,6 +23,11 @@ class User < ApplicationRecord
       user.name = auth.info.name
       user.email = auth.info.email
       user.password = Devise.friendly_token[0, 20]
+
+      if auth.info.image.present?
+      downloaded_image = URI.open(auth.info.image)
+      user.avatar.attach(io: downloaded_image, filename: "#{user.name}_avatar.jpg")
+      end
     end
   end
 
@@ -30,5 +41,25 @@ class User < ApplicationRecord
 
   def self.ransackable_attributes(auth_object = nil)
     [ "name" ]
+  end
+
+    def google_avatar_url
+      # OAuth情報があればURLを返す
+      @google_avatar_url ||= begin
+      omniauth_data = self[:omniauth_data] # セッション等に保存しておく場合
+      omniauth_data[:info][:image] if omniauth_data
+    end
+  end
+
+  def profile_image_url
+    if avatar.attached?
+      # Active Storageの画像を優先
+      Rails.application.routes.url_helpers.url_for(avatar)
+    elsif google_avatar_url.present?
+      # Google認証で取得した画像URL
+      google_avatar_url
+    else
+      nil # デフォルト画像はDecoratorで処理
+    end
   end
 end

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -14,12 +14,7 @@
               <!-- 画像 -->
               <figure class="flex-shrink-0 w-30 md:w-50">
                 <div class="aspect-square overflow-hidden">
-                  <% if product.image.attached? %>
-                    <%= image_tag product.image.variant(resize_to_fill: [400, 400], format: :webp, saver: { quality: 85 }), 
-                                  class: "w-30 h-30 md:w-40 md:h-40 object-cover" %>
-                  <% else %>
-                    <%= image_tag "default_image.png", class: "w-30 h-30 md:w-40 md:h-40 object-cover" %>
-                  <% end %>
+                  <%= product.decorate.product_image(class: "w-30 h-30 md:w-40 md:h-40") %>
                 </div>
               </figure>
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -25,16 +25,6 @@
                       file:bg-accent file:transition file:duration-200 file:hover:brightness-96
                       file:text-neutral
                       cursor-pointer" %>
-        <% else %>
-          <% if @post.product.image.attached? &&
-                @post.product.image.blob.present? &&
-                @post.product.image.blob.persisted? &&
-                @post.product.image.filename.to_s != "default.png" %>
-            <div class="flex justify-center">
-              <%= image_tag @post.product.image.variant(resize_to_fill: [400, 400], format: :webp, saver: { quality: 85 }),
-                            class: "w-50 h-50 object-cover" %>
-            </div>
-          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -8,7 +8,7 @@
         <% if post.product.image.attached? %>
           <%= image_tag post.product.image.variant(resize_to_fill: [400, 400], format: :webp, saver: { quality: 85 }), class: "w-45 h-45 object-cover" %>
         <% else %>
-          <%= image_tag "default_image.png", class: "w-45 h-45 object-cover" %>
+          <%= image_tag "default_image.png", class: "w-30 h-30 md:w-45 md:h-45 object-cover" %>
         <% end %>
       </div>
     </figure>
@@ -17,7 +17,8 @@
     <div class="card-body flex-1 min-w-0 flex py-2 flex-col text-neutral justify-between">
       <div class="flex-1">
         <p class="text-sm mb-2">
-          <%= link_to user_path(post.user), class: "flex items-center gap-1 hover:opacity-70" do %>
+          <%= link_to user_path(post.user), class: "flex items-center gap-2 hover:opacity-70" do %>
+            <span><%= post.user.decorate.avatar_image(class: "w-8 h-8") %></span>
             <span><%= post.user.name %></span>
             <span>｜</span>
             <span><%= time_ago_in_words(post.created_at) %>前</span>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -7,11 +7,7 @@
     <div class="flex flex-col justify-center items-center sm:flex-row sm:items-start sm:gap-6">
       <!-- 商品画像 -->
       <div class="aspect-square overflow-hidden p-4">
-        <% if @post.product.image.attached? %>
-          <%= image_tag @post.product.image.variant(resize_to_fill: [400, 400], format: :webp, saver: { quality: 85 }), class: "w-50 h-50 object-cover" %>
-        <% else %>
-          <%= image_tag "default_image.png", class: "w-50 h-50 object-cover" %>
-        <% end %>
+        <%= @post.product.decorate.product_image(class: "w-40 h-40") %>
       </div>
 
       <div class="flex flex-col justify-start items-start gap-2 md:gap-5 text-neutral px-10 md:px-0 py-6">
@@ -21,7 +17,7 @@
         
         <div class="flex flex-col text-base">
           <%= link_to user_path(@post.user), class: "flex items-center gap-2 hover:opacity-70" do %>
-            <%= image_tag "footer/user_circle.svg", class: "h-10 w-10" %>
+            <%= @post.user.decorate.avatar_image(class: "w-10 h-10") %>
             <span class="font-medium"><%= @post.user.name %></span>
           <% end %>
         </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,66 +1,109 @@
 <div class="p-1 md:p-4">
-  <div class="flex flex-col p-2 md:p-6 items-center justify-center w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
+  <div class="flex flex-col p-2 md:p-6 w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
     <h1 class="text-center text-xl md:text-2xl p-4 border-b border-gray-300 w-full">
       <%= t('.title') %>
     </h1>
   
     <%= form_with model: @user, url: profile_path, method: :put do |f| %>
-      <% if @user.errors.any? %>
-        <div class="error-messages text-error bg-base-100 p-2 md:p-4 rounded-4xl ring-2 ring-error">
-          <ul>
-            <% @user.errors.full_messages.each do |message| %>
-              <li><%= message %></li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
-
-      <!-- ユーザー情報 -->
-      <div class="p-6">
-        <div class="mb-3 md:mb-6 w-full">
-          <%= f.label :name, class: "form-label" %>
-          <%= f.text_field :name, class: "input input-bordered w-full" %>
-        </div>
-
-        <% if @google_user %>
-          <div class="mb-3 md:mb-6 w-full">
-            <%= t('activerecord.attributes.user.email') %>
-            <div class="border-2 border-[var(--color-base-400)] rounded-2xl w-full bg-base-200 py-2 px-3 text-sm">
-              <%= @user.email %>
-            </div>
-            <div class="mt-4">
-              <label class="form-label"><%=t('.authentication') %></label>
-            </div>
-            <div class="inline-flex items-center border-2 border-[var(--color-base-400)]
-                        bg-white text-bg-neutral rounded-2xl p-3 w-auto">
-              <img src="https://developers.google.com/identity/images/g-logo.png"
-                  alt="Google Logo" class="h-5 mr-2" />
-              <span class="font-roboto text-sm"><%= t('.google') %></span>
-              <span class="px-2 text-xs">
-                <span class="font-roboto bg-accent px-3 py-1 rounded-xl">
-                  <%= t('.google_user') %>
-                </span>
-              </span>
-            </div>
-          </div>
-        <% else %>
-          <div class="mb-3 md:mb-6 w-full">
-            <%= f.label :email, class: "form-label" %>
-            <%= f.email_field :email, class: "input input-bordered w-full" %>
+      <div class="w-full max-w-md mx-auto p-4">
+        <% if @user.errors.any? %>
+          <div class="error-messages text-error bg-base-100 p-2 md:p-4 rounded-4xl ring-2 ring-error">
+            <ul>
+              <% @user.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+              <% end %>
+            </ul>
           </div>
         <% end %>
+      </div>
 
-        <div class="mb-3 md:mb-6 w-full">
-          <%= f.label :self_introduction, class: "form-label" %>
-          <%= f.text_area :self_introduction, class: "textarea textarea-bordered w-full", rows: 5 %>
-        </div>
+      <div class="w-full flex flex-col items-center justify-center">
+        <div class="w-full max-w-3xs md:max-w-2xs mx-auto">
+          <!-- ユーザー情報 -->
+          <div class="mb-3 md:mb-6">
+            <% if @user.avatar.attached? %>
+              <%= f.label :avatar, 
+                          t('activerecord.attributes.user.current_avatar'), 
+                          class: "form-label block text-center" %>
+            <% else %>
+              <%= f.label :avatar, 
+                          t('activerecord.attributes.user.avatar'), 
+                          class: "form-label block mb-2" %>
+            <% end %>
+
+           <% if @user.avatar.attached? &&
+                 @user.avatar.blob.present? &&
+                 @user.avatar.blob.persisted? &&
+                 @user.avatar.filename.to_s %>
+              <div class="flex justify-center p-4">
+                <%= @user.decorate.avatar_image(class: "w-15 h-15 md:w-20 md:h-20") %>
+              </div>
+            <% end %>
+            <%= f.file_field :avatar,
+                class: "block w-full mx-auto text-xs md:text-sm text-base-300
+                        file:mr-4 file:py-2 file:px-2 bg-base-100 rounded-xl 
+                        ring-2 ring-[var(--color-base-400)]
+                        file:rounded-l-lg
+                        file:text-sm
+                        file:bg-primary file:transition file:duration-200
+                        file:hover:brightness-96
+                        file:text-neutral
+                        cursor-pointer" %>
+          </div>
+
+          <div class="mb-3 md:mb-6">
+            <%= f.label :name, class: "form-label" %>
+            <%= f.text_field :name, class: "input input-bordered w-full" %>
+          </div>
+
+          <% if @google_user %>
+            <div class="mb-3 md:mb-6">
+              <%= t('activerecord.attributes.user.email') %>
+              <div class="border-2 border-[var(--color-base-400)] rounded-2xl w-full bg-base-200 py-2 px-3 text-sm">
+                <%= @user.email %>
+              </div>
+              <div class="mt-4">
+                <label class="form-label"><%=t('.authentication') %></label>
+              </div>
+              <div class="inline-flex items-center border-2 border-[var(--color-base-400)]
+                          bg-white text-bg-neutral rounded-2xl p-3 w-auto">
+                <img src="https://developers.google.com/identity/images/g-logo.png"
+                    alt="Google Logo" class="h-5 mr-2" />
+                <span class="font-roboto text-sm"><%= t('.google') %></span>
+                <span class="px-2 text-xs">
+                  <span class="font-roboto bg-accent px-3 py-1 rounded-xl">
+                    <%= t('.google_user') %>
+                  </span>
+                </span>
+              </div>
+            </div>
+          <% else %>
+            <div class="mb-3 md:mb-6 w-full">
+              <%= f.label :email, class: "form-label" %>
+              <%= f.email_field :email, class: "input input-bordered w-full" %>
+            </div>
+          <% end %>
+
+          <div class="mb-3 md:mb-6">
+            <%= f.label :self_introduction, class: "form-label" %>
+            <%= f.text_area :self_introduction, class: "textarea textarea-bordered w-full", rows: 4 %>
+          </div>
+
+      </div>
 
         <!-- 更新 -->
-        <div class="flex flex-col gap-4 p-4 md:p-6 w-full">
+        <div class="gap-4 p-3">
           <div class="flex justify-center w-full">
             <%= f.submit t('helpers.submit.update'), class: "text-sm md:text-base ring-secondary action-button" %>
           </div>
         </div>
+
+        <%=link_to profile_path, class: "p-1" do%>
+          <div class="flex justify-center w-full">
+            <div class="text-sm md:text-base ring-accent action-button" >
+            戻る
+          </div>
+        <% end %>
       </div> 
     <% end %>
   </div>

--- a/app/views/shared/_user_profile.html.erb
+++ b/app/views/shared/_user_profile.html.erb
@@ -1,43 +1,39 @@
 <div class="p-1 md:p-4">
-  <div class="flex flex-col p-2 md:p-6 items-center justify-center w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
+  <div class="flex flex-col p-2 md:p-6 w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
     <h1 class="text-center text-xl md:text-2xl p-4 border-b border-gray-300 w-full">
-      <% if user == current_user %>
-        <%= t('profiles.show.title') %>
-      <% else %>
-        <%= t('profiles.info') %>
-      <% end %>
+      <%= user == current_user ? t('profiles.show.title') : t('profiles.info') %>
     </h1>
 
     <!-- ユーザー情報 -->
-    <div class="flex flex-col justify-center items-center sm:items-start gap-4">
-      <div class="flex flex-row gap-2 md:gap-6 pt-6">
-        <div class="text-base md:text-xl">
-          <%= user.name %>
-        </div>
+    <div class="flex flex-col justify-center items-center sm:flex-row sm:items-start sm:gap-6 w-full py-4">
+      <div class="aspect-square overflow-hidden md:p-4">
+        <%= user.decorate.avatar_image(class: "w-15 h-15 md:w-25 md:h-25 rounded-full object-cover") %>
       </div>
 
-      <% if user.self_introduction.present? %>
-        <div class="flex flex-col rounded-xl py-2 md:py-3 text-sm">
-          <span><%= user.self_introduction %></span>
+      <div class="flex flex-col justify-center items-center gap-2 md:gap-4 text-neutral py-4 px-2">
+        <div class="text-lg md:text-xl font-semibold break-words">
+          <%= user.name %>
         </div>
-      <% end %>
 
-      <!-- 編集 -->
-      <% if user == current_user %>
-        <div class="flex flex-col gap-4 p-1 md:p-2 w-full">
-          <div class="flex justify-end w-full">
+        <div class="text-sm md:text-base break-words max-w-[20ch] md:min-h-[1.5rem]">
+          <%= user.self_introduction.presence || "" %>
+        </div>
+
+        <!-- 編集 -->
+        <% if user == current_user %>
+          <div class="flex w-full mt-2 justify-center sm:justify-end">
             <%= link_to edit_profile_path, class: "text-sm ring-accent action-button", data: { turbo: false } do %>
               <%= t('helpers.submit.edit') %>
             <% end %>
           </div>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
     </div>
 
     <!-- チャート -->
     <% if sweetness_profiles.present? %>
-      <div class="flex justify-center p-2 w-full">
-        <div class="w-full max-w-lg md:max-w-xl p-2 rounded-3xl bg-base-100">
+      <div class="flex justify-center md:p-2 w-full">
+        <div class="w-full max-w-md md:max-w-lg p-2 rounded-3xl bg-base-100">
 
           <div class="flex justify-end text-sm md:text-base font-bold mb-2">
             <span class="rounded-full bg-secondary text-white px-3 py-2 text-sm md:text-base">
@@ -76,7 +72,7 @@
         <div class="text-center py-6 text-sm md:text-base text-[var(--color-base-400)]">
           <%= raw t('profiles.diagnosis.no_data') %>
         </div>
-        <div class="flex justify-end">
+        <div class="flex justify-center">
           <%= link_to new_diagnosis_path, class: "text-sm bg-primary action-button-primary hover-animation", data: { turbo: false } do %>
             <%= t('defaults.buttons.take_diagnosis') %>
           <% end %>
@@ -90,7 +86,7 @@
       <input type="radio" name="my_tabs_4" role="tab"
         class="tab text-xs md:text-base text-primary hover:text-primary"
         aria-label="<%= t('profiles.tabs.posts') %>" checked />
-      <div role="tabpanel" class="tab-content bg-base-100 md:p-6 border-primary rounded-4xl w-full">
+      <div role="tabpanel" class="tab-content md:p-6 border-primary rounded-4xl w-full">
         <div class="flex flex-col mx-auto items-center justify-center text-xs md:text-sm w-full">
           <% if @posts.present? %>
             <%= render @posts %>
@@ -104,7 +100,7 @@
       <input type="radio" name="my_tabs_4" role="tab"
         class="tab text-xs md:text-base text-accent hover:text-accent"
         aria-label="<%= t('profiles.tabs.bookmarks') %>" />
-      <div role="tabpanel" class="tab-content bg-base-100 md:p-6 border-accent rounded-4xl w-full">
+      <div role="tabpanel" class="tab-content md:p-6 border-accent rounded-4xl w-full">
         <div class="flex flex-col mx-auto items-center justify-center text-xs md:text-sm w-full">
           <p class="p-4"><%= t('profiles.empty_states.no_bookmarks') %></p>
         </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -15,6 +15,8 @@ ja:
       created_at: 作成日時
       updated_at: 更新日時
       user:
+        avatar: プロフィール画像
+        current_avatar: 現在のプロフィール画像
         self_introduction: ひとこと
         current_password: 現在のパスワード
         email: メールアドレス

--- a/test/decorators/post_decorator_test.rb
+++ b/test/decorators/post_decorator_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class PostDecoratorTest < Draper::TestCase
+end

--- a/test/decorators/product_decorator_test.rb
+++ b/test/decorators/product_decorator_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class ProductDecoratorTest < Draper::TestCase
+end

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class UserDecoratorTest < Draper::TestCase
+end


### PR DESCRIPTION
## 概要
ユーザープロフィール画像の管理機能を実装しました。  
Googleログインユーザーの画像取得からActive Storageでの保存、デフォルト画像設定、ビューでのリサイズ対応までを行いました。

## 📋 主な実装内容
- Userモデルに `has_one_attached :avatar` を追加
- Googleログイン時にOmniAuthからプロフィール画像URLを取得し、Active Storageに保存
- デフォルトアバター画像を設定
- モジュール（ImageValidatable）でアバター画像のバリデーションを追加  
  （拡張子チェック、ファイルサイズ上限 5MB）
- DraperのDecoratorを導入し、画像処理をDecoratorに分離
- ja.yml に avatar 関連のI18n文言を追加
- プロフィール編集画面からアバター画像の編集・更新を可能に
- 各投稿にアバター画像が表示されること

## 技術的に考慮した内容
- モジュールでバリデーションを切り出し、責務を分離
- Decoratorでリサイズ処理を実装し、ビューの肥大化を回避

## ✅ 確認事項
- [ ] S3にアバター画像が保存されることを確認
- [ ] Googleログイン時にプロフィール画像が自動取得・保存されること
- [ ] プロフィール編集画面から画像のアップロード・更新ができること
- [ ] 非対応のファイル形式をアップロードするとエラーになること
- [ ] 5MBを超える画像をアップロードするとエラーになること

close #41 