### PR TITLE
Feature/#135 admin basic setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ erDiagram
         datetime reset_password_sent_at "リセットメール送信日時"
         datetime remember_created_at "自動ログイン設定日時"
         string provider "外部ログインのサービス名（Google）"
-        string uid "外部サービス上のユーザーID" 
+        string uid "外部サービス上のユーザーID"
+        int role "ユーザー区分"
         datetime created_at "作成日時"
         datetime updated_at "更新日時"
     }

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,17 @@
+class Admin::BaseController < ApplicationController
+  before_action :check_admin
+  layout "admin/layouts/application"
+
+  private
+
+  def not_authenticated
+    flash[:warning] = t("defaults.flash_message.require_login")
+    redirect_to admin_login_path
+  end
+
+  def check_admin
+    unless current_user&.admin?
+      redirect_to root_path, danger: t("defaults.flash_message.not_authorized")
+    end
+  end
+end

--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,0 +1,3 @@
+class Admin::DashboardsController < Admin::BaseController
+  def index;end
+end

--- a/app/controllers/admin/user_sessions_controller.rb
+++ b/app/controllers/admin/user_sessions_controller.rb
@@ -1,0 +1,23 @@
+class Admin::UserSessionsController < Admin::BaseController
+  skip_before_action :authenticate_user!
+  skip_before_action :check_admin, only: %i[new create]
+  layout "admin/layouts/application"
+
+  def new;end
+
+  def create
+    user = User.find_by(email: params[:email])
+    if user&.valid_password?(params[:password]) && user.admin?
+      sign_in(user)
+      redirect_to admin_root_path, notice: t(".success")
+    else
+      flash.now[:alert] = t(".failure")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    sign_out(current_user) if current_user
+    redirect_to admin_login_path, success: t(".success")
+  end
+end

--- a/app/controllers/admin/user_sessions_controller.rb
+++ b/app/controllers/admin/user_sessions_controller.rb
@@ -1,5 +1,5 @@
 class Admin::UserSessionsController < Admin::BaseController
-  skip_before_action :authenticate_user!
+  skip_before_action :authenticate_user!, only: %i[new create]
   skip_before_action :check_admin, only: %i[new create]
   layout "admin/layouts/application"
 
@@ -17,7 +17,11 @@ class Admin::UserSessionsController < Admin::BaseController
   end
 
   def destroy
-    sign_out(current_user) if current_user
-    redirect_to admin_login_path, success: t(".success")
+    if current_user
+      sign_out(current_user) 
+      redirect_to admin_login_path, notice: t(".success")
+    else
+      redirect_to admin_login_path, alert: t(".failure")
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,14 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
+  before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
   allow_browser versions: :modern
 
   rescue_from ActiveRecord::RecordNotFound do |exception|
     redirect_to root_path, alert: "無効なURLです"
+  end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :role ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :role ])
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,4 +1,5 @@
 class CategoriesController < ApplicationController
+  skip_before_action :authenticate_user!
   def index
     @categories = Category.all.order(:name)
   end

--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -1,4 +1,5 @@
 class DiagnosesController < ApplicationController
+  skip_before_action :authenticate_user!
   DIAGNOSIS_QUESTIONS = YAML.load_file(Rails.root.join("config/diagnosis_questions.yml"))["questions"]
 
   def new

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,4 @@
 class StaticPagesController < ApplicationController
+  skip_before_action :authenticate_user!
   def top;end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,8 @@ class User < ApplicationRecord
   has_many :bookmarks, dependent: :destroy
   has_many :bookmark_products, through: :bookmarks, source: :product
 
+  enum :role, { general: 0, admin: 1 }
+
   # providerとuidを使ってユーザーを検索、存在しなければ新規作成
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|

--- a/app/views/admin/dashboards/index.html.erb
+++ b/app/views/admin/dashboards/index.html.erb
@@ -1,0 +1,6 @@
+<div class="p-1 md:p-4">
+  <div class="flex flex-col p-2 md:p-6 items-center justify-center w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
+    <h1 class="text-center text-xl md:text-2xl p-4 border-b border-gray-300 w-full">
+      <%= t('.title') %></h1>
+  </div>
+</div>

--- a/app/views/admin/layouts/admin_login.html.erb
+++ b/app/views/admin/layouts/admin_login.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>あまピタッ！| 管理画面</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/admin/layouts/application.html.erb
+++ b/app/views/admin/layouts/application.html.erb
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html data-theme="amapita">
+  <head>
+    <title>あまピタッ！| 管理画面</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= yield :head %>
+
+    <link rel="manifest" href="/manifest.json">
+    <link rel="icon" href="/icon.png" type="image/png">
+    <link rel="icon" href="/icon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="/icon.png">
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Kiwi+Maru&display=swap" rel="stylesheet">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+
+    <style>
+      body {
+        background-image: url('<%= asset_path("bg_mobile.webp") %>');
+      }
+
+      @media (min-width: 768px) {
+        body {
+          background-image: url('<%= asset_path("bg_pc.webp") %>');
+        }
+      }
+    </style>
+  </head>
+
+  <body class="min-h-screen flex flex-col bg-center bg-no-repeat bg-fixed bg-cover font-kiwi">
+    <%= render 'admin/shared/header' %>
+    <main class="container flex-1 pt-20 pb-14 md:pb-20 px-4 mx-auto">
+      <% if notice.present? %>
+        <%= render 'shared/notice', notice: notice %>
+      <% end %>
+      <% if alert.present? %>
+        <%= render 'shared/alert', alert: alert %>
+      <% end %>
+      <%= yield %>
+    </main>
+  </body>
+</html>

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -1,0 +1,27 @@
+<div class="navbar bg-base-200 shadow-sm">
+  <div class="flex-1">
+    <%= link_to admin_root_path, class: "inline-block px-2" do %>
+      <%= image_tag "logo.webp", class: "h-12 md:h-14 w-auto" %>
+    <% end %>
+  </div>
+
+  <% if user_signed_in? %>
+    <div class="flex-none">
+      <ul class="menu menu-horizontal px-8">
+        <li>
+          <details>
+            <summary>Menu</summary>
+            <ul class="menu menu-sm dropdown-content bg-base-100 rounded-t-none p-2">
+              <li>
+                <%= link_to t('admin.shared.header.logout'), admin_logout_path, 
+                    data: { turbo_method: :delete }, 
+                    local: true,
+                    class: 'whitespace-nowrap' %>
+              </li>
+            </ul>
+          </details>
+        </li>
+      </ul>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/user_sessions/new.html.erb
+++ b/app/views/admin/user_sessions/new.html.erb
@@ -1,0 +1,28 @@
+<main class="container flex-1 pt-4 pb-14 md:pb-20 px-4 mx-auto flex items-center justify-center">
+  <div class="w-full max-w-md bg-base-200 rounded-3xl px-4 md:px-10 md:py-6">
+    <div class="mb-6 text-center">
+      <h2 class="text-2xl text-neutral font-bold pt-4"><%= t('.title') %></h2>
+    </div>
+
+    <%= form_with url: admin_login_path, data: { turbo: false } do |f| %>
+      <div class="form-control mb-4 p-2">
+        <%= f.email_field :email, 
+            autofocus: true, 
+            autocomplete: "email", 
+            placeholder: "メールアドレス",
+            class: "input input-bordered w-full h-10 md:h-12 rounded-full px-4 py-2 focus:outline-none" %>
+      </div>
+
+      <div class="form-control mb-4 p-2">
+        <%= f.password_field :password, 
+            autocomplete: "current-password", 
+            placeholder: "パスワード",
+            class: "input input-bordered w-full h-10 md:h-12 rounded-full px-4 py-2 focus:outline-none" %>
+      </div>
+
+      <div class="form-control flex justify-center pb-4">
+        <%= f.submit t('.login'), class: "bg-secondary button-primary" %>
+      </div>
+    <% end %>
+  </div>
+</main>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -10,6 +10,8 @@ ja:
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新出来ませんでした"
       deleted: "%{item}を削除しました"
+      require_login: ログインしてください
+      not_authorized: 権限がありません
     label:
       stats: "%{count}人中%{perfect}人があまピタッ！"
       no_rating: あまピタ評価はまだありません
@@ -41,6 +43,22 @@ ja:
       search: 検索
       clear: クリア
       post: 投稿する
+  admin:
+    user_sessions:
+      new:
+        title: ログイン
+        login: ログイン
+      create:
+        success: ログインしました
+        failure: ログインに失敗しました
+      destroy:
+        success: ログアウトしました
+    dashboards:
+      index:
+        title: ダッシュボード
+    shared:
+      header:
+        logout: ログアウト
   profiles:
     info: ユーザー情報
     tabs:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -53,6 +53,7 @@ ja:
         failure: ログインに失敗しました
       destroy:
         success: ログアウトしました
+        failure: 既にログアウトしています
     dashboards:
       index:
         title: ダッシュボード

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,15 @@ Rails.application.routes.draw do
     resources :products, only: %i[show]
   end
 
+  namespace :admin do
+    root "dashboards#index"
+    resource :dashboard, only: %i[index]
+
+    get "login", to: "user_sessions#new"
+    post "login", to: "user_sessions#create"
+    delete "logout", to: "user_sessions#destroy"
+  end
+
   get "up" => "rails/health#show", as: :rails_health_check
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest

--- a/db/migrate/20250908020836_add_role_to_users.rb
+++ b/db/migrate/20250908020836_add_role_to_users.rb
@@ -1,0 +1,6 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :role, :integer, default: 0, null: false
+    add_index :users, :role
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_06_230550) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_08_020836) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -128,8 +128,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_06_230550) do
     t.string "uid"
     t.bigint "sweetness_type_id"
     t.string "self_introduction"
+    t.integer "role", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["role"], name: "index_users_on_role"
     t.index ["sweetness_type_id"], name: "index_users_on_sweetness_type_id"
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end


### PR DESCRIPTION
## 概要
管理者画面のログイン機能を実装しました。

## 📋 機能実装
- **ユーザーロール機能を追加**  
  - User モデルに `role` カラム（enum型）を追加
- **管理者専用ログイン機能を実装**  
  - Admin::UserSessionsController で管理者専用ログイン画面を作成
  - 管理者権限チェック機能を Admin::BaseController に実装
- **管理画面ダッシュボードを追加**
  - Admin::DashboardsController でダッシュボード機能を実装
  - 管理画面専用レイアウトとビューを作成
- **Devise認証の全体適用**
  - ApplicationController に `before_action :authenticate_user!` を設定
  - 必要な画面で `skip_before_action` による認証除外を実装

### 🎨 UI/UX 関連
- 管理画面専用のレイアウトデザインを作成
- 管理者ログイン画面のデザインを実装
- ダッシュボードの基本構造を作成

### 🔧 修正・設定
- ルーティングに管理画面用の namespace を追加
- i18n の日本語ファイル（`config/locales/views/ja.yml`）に管理画面関連の翻訳を追記
- README.md を更新してroleカラムの説明を追加
- 
### ✅ 確認項目
[x] 管理者ユーザーで管理画面にアクセスできること
[x] 一般ユーザーが管理画面にアクセスできないこと
[x] 非ログイン時は適切にログイン画面にリダイレクトされること
[x] 管理者専用ログイン画面が正常に表示されること
[x] 管理画面ダッシュボードが正常に表示されること
[x] 認証除外設定が適切に動作すること

close #135 