### PR TITLE
Feat/#155 admin post management

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,0 +1,16 @@
+class Admin::PostsController < Admin::BaseController
+  before_action :authenticate_user!
+
+  def index
+    @q = Post.ransack(params[:q])
+    @posts = @q.result(distinct: true).all.order(created_at: :desc).decorate
+    @total_count = @posts.count
+  end
+
+  def destroy
+    @post = Post.find(params[:id])
+    @post.image.purge if @post.image.attached?
+    @post.destroy!
+    redirect_to admin_posts_path, notice: t("defaults.flash_message.deleted", item: Post.model_name.human)
+  end
+end

--- a/app/views/admin/posts/_search_form.html.erb
+++ b/app/views/admin/posts/_search_form.html.erb
@@ -1,0 +1,47 @@
+<%= search_form_for q, url: admin_posts_path, method: :get,
+    class: 'p-1 md:p-4 flex justify-center',
+    data: { search_clear_target: "form" } do |f| %>
+
+  <div class="bg-base-200 rounded-4xl p-4 md:p-6 max-w-md md:max-w-4xl mx-auto flex flex-col items-center gap-4">
+
+    <!-- キーワード検索 -->
+    <div class="flex flex-row items-stretch md:items-center gap-3 w-full">
+      <%= f.search_field :review_or_product_name_or_user_name_or_category_name_or_product_manufacturer_cont, 
+        class: "flex-1 bg-white p-2 rounded-4xl ring-2 w-full md:w-100 ring-[var(--color-base-400)] text-sm px-4",
+        placeholder: t('defaults.placeholders.search_word'),
+        data: { search_clear_target: "input" } %>
+
+      <%= f.submit t('helpers.submit.search'), class: "ring-secondary search-form-button text-base" %>
+
+      <button type="button" onclick="location.href='<%= url_for(only_path: true) %>'"
+              class="ring-[var(--color-base-400)] search-form-button text-base whitespace-nowrap">
+        <%= t('helpers.submit.clear') %>
+      </button>
+    </div>
+
+    <!-- 詳細検索 -->
+    <div class="w-full">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 px-8 md:px-6">
+
+          <!-- カテゴリ -->
+          <div class="col-span-1">
+            <%= f.select :category_name_eq,
+                  Category.all.pluck(:name, :name),
+                  { include_blank: t('activerecord.models.category') },
+                  class: "select w-full text-sm bg-white py-2",
+                  data: { search_clear_target: "select" } %>
+          </div>
+
+          <!-- メーカー -->
+          <div class="col-span-1">
+            <%= f.select :product_manufacturer_eq,
+                  I18n.t('products.manufacturers.list'),
+                  { include_blank: t('activerecord.attributes.product.manufacturer') },
+                  class: "select w-full text-sm bg-white",
+                  data: { search_clear_target: "select" } %>
+          </div>
+        </div>
+    </div>
+    <%= t('admin.posts.search_form.total_count', count: @total_count) %>
+  </div>
+<% end %>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,0 +1,61 @@
+<div class="flex flex-col p-2 items-center justify-center w-full max-w-xl sm:max-w-3xl md:max-w-6xl mx-auto bg-base-200 rounded-4xl">
+  <h1 class="text-center text-xl md:text-2xl p-4 border-b border-gray-300 w-full">
+    <%= t('.title') %>
+  </h1>
+
+  <%= render 'search_form', q: @q, url: admin_posts_path %>
+
+  <% if @posts.present? %>
+    <div class="w-full p-3">
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+        <% @posts.each do |post| %>
+        <!-- カード -->
+        <div class="card bg-base-200 p-2 md:p-4 ring-1 ring-[var(--color-base-400)] min-h-52 rounded-4xl flex flex-col relative">
+          <!-- 画像 -->
+          <figure class="flex-shrink-0 w-full">
+            <div class="aspect-square overflow-hidden rounded-none">
+              <%= post.decorate.post_image(class: "w-20 h-20 md:w-30 md:h-30") %>
+            </div>
+          </figure>
+                
+          <!-- 投稿情報 -->
+          <div class="card-body flex-1 min-w-0 flex py-2 flex-col text-neutral justify-between">
+            <div class="flex-1">
+              <div class="flex items-center text-xs md:text-sm justify-between py-1 text-base-300">
+                <%= post.product.category.name %>
+              </div>
+              <div class="flex items-center text-xs md:text-sm justify-between py-1 text-base-300">
+                <%= post.product.manufacturer %>
+              </div>
+              <div class="card-title text-sm line-clamp-3">
+                <%= post.product.name %>
+              </div>
+              <div class="card-title text-xs md:text-sm p-2">
+                <%= post.user.decorate.avatar_image(class: "w-8 h-8") %>
+                <%= post.user.name %>
+              </div>
+              <% if post.review.present? %>
+                <div class="card-title text-xs md:text-sm line-clamp-6">
+                  <%= post.review %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+              <!-- 削除ボタン -->
+              <div class="flex justify-end">
+                <%= link_to admin_post_path(post),
+                    class: "text-sm ring-secondary action-button",
+                    data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+                    <%= t('helpers.submit.delete') %>
+                <% end %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% else %>
+      <div class="mb-3">投稿がありません</div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/products/_form.html.erb
+++ b/app/views/admin/products/_form.html.erb
@@ -64,7 +64,7 @@
     </div>
 
     <div class="form-control p-6">
-      <%= f.submit f.object.new_record? ? t('helpers.submit.product') : t('helpers.submit.update'),
+      <%= f.submit f.object.new_record? ? t('helpers.submit.create') : t('helpers.submit.update'),
             class: "bg-primary button-primary" %>
     </div>
 

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -1,10 +1,8 @@
 <div class="navbar bg-base-200 shadow-sm px-4 md:px-6 relative">
-  <!-- 左端ロゴ -->
   <div class="flex-shrink-0">
     <%= image_tag "logo.webp", class: "h-12 md:h-14 w-auto" %>
   </div>
 
-  <!-- 右端メニュー -->
   <% if user_signed_in? && current_user.admin? %>
     <div class="ml-auto">
       <div class="drawer drawer-end">
@@ -21,6 +19,10 @@
             </li>
             <li>
               <%= link_to t('admin.products.new.title'), new_admin_product_path, 
+                  class: 'whitespace-nowrap text-base' %>
+            </li>
+            <li>
+              <%= link_to t('admin.posts.index.title'), admin_posts_path, 
                   class: 'whitespace-nowrap text-base' %>
             </li>
             <li>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -33,7 +33,7 @@
     <% if @post.product.persisted? %>
       <%= f.hidden_field :product_id, value: @post.product.id %>
       <div class="flex justify-center w-full">
-        <div class="bg-base-100 p-4 rounded-4xl text-sm text-neutral w-fit ring-primary ring-2">
+        <div class="p-4 rounded-4xl text-sm text-neutral w-fit ring-[var(--color-base-400)] ring-2">
         <span class="text-left inline-block leading-loose">
           <p><%=t('activerecord.attributes.product.name') %>：<%= @post.product.name %></p>
           <p><%=t('activerecord.attributes.product.manufacturer') %>：<%= @post.product.manufacturer %></p>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -71,6 +71,11 @@ ja:
         title: 商品の編集
       search_form:
         total_count: "商品数：%{count} 件"
+    posts:
+      index:
+        title: 投稿一覧
+      search_form:
+        total_count: "投稿数：%{count} 件"
     shared:
       header:
         logout: ログアウト

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
 
     resource :dashboard, only: %i[index]
     resources :products
+    resources :posts, only: %i[index destroy]
   end
 
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
## 概要
管理画面での投稿管理機能（一覧表示・削除・検索）を実装しました。  

---

### 📋 実装内容
  - 管理画面用のPostsコントローラー・ルーティングを追加
    - index・destroyアクション
    - 一覧画面に検索機能を追加
    - 管理者認証フィルターを追加
  - ヘッダーメニューからの画面遷移
  - i18nの追記

### 🔧その他微修正
- 一般画面での商品投稿画面のUI修正
- 管理画面での商品登録画面のi18nの修正
---

### ✅ 確認事項
- [x] 管理画面で削除された投稿がユーザー画面でも削除されていること
- [x] 削除ボタンを押すと確認のポップが表示されること
- [x] ユーザーがアップロードした投稿が一覧画面に表示されること

### 今後実装予定
- [ ] ページネーション

close #155 