### PR TITLE
Feature/#42 sweetness twin badges

### DIFF
--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -15,7 +15,7 @@ class DiagnosesController < ApplicationController
       return
     end
 
-    diagnoser = Diagnosis::SweetnessDiagnoser.new(diagnosis_params)
+    diagnoser = Diagnosis::SweetnessTypeProcessor.new(diagnosis_params)
     result = diagnoser.call
 
     sweetness_type = SweetnessType.find_by(sweetness_kind: SweetnessType.sweetness_kinds[result[:sweetness_kind].to_s])

--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -30,6 +30,7 @@ class DiagnosesController < ApplicationController
     )
     if current_user
       current_user.update(sweetness_type_id: profile.sweetness_type_id)
+      SweetnessTwinBadge.refresh_for(current_user) if current_user
     end
     redirect_to diagnosis_result_path(profile.token)
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -23,7 +23,7 @@ class PostsController < ApplicationController
     @post = current_user.posts.build(post_params)
     if @post.save
       # バッジの付与
-      new_badge = BadgeService.check_and_award_post_badges(current_user)
+      new_badge = PostBadge.check_and_award_post_badges(current_user)
       # 新しいバッジであればモーダル表示
       flash[:badge_awarded] = new_badge.name if new_badge
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -13,6 +13,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @user = User.from_omniauth(request.env["omniauth.auth"])
 
     if @user.persisted?
+      SweetnessTwinBadge.refresh_for(@user)
       sign_in_and_redirect @user, event: :authentication
       set_flash_message(:notice, :success, kind: provider.to_s.capitalize) if is_navigational_format?
     else

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -25,6 +25,7 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   def after_sign_in_path_for(resource)
+    SweetnessTwinBadge.refresh_for(resource)
     root_path
   end
 

--- a/app/helpers/badge_helper.rb
+++ b/app/helpers/badge_helper.rb
@@ -1,6 +1,6 @@
 module BadgeHelper
   def display_post_badge(user)
-    badge = BadgeService.current_post_badge(user)
+    badge = PostBadge.current_post_badge(user)
     badge&.name  # nil(投稿バッジがない)場合は何も返さない
   end
 end

--- a/app/helpers/badge_helper.rb
+++ b/app/helpers/badge_helper.rb
@@ -1,6 +1,11 @@
 module BadgeHelper
   def display_post_badge(user)
     badge = PostBadge.current_post_badge(user)
-    badge&.name  # nil(投稿バッジがない)場合は何も返さない
+    badge&.name
+  end
+
+  def display_sweetness_twin_badge(user)
+    badge = SweetnessTwinBadge.current_twin_badge(user)
+    badge&.name
   end
 end

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -12,4 +12,6 @@ class Badge < ApplicationRecord
 
   scope :post_badges, -> { where(badge_kind: :post_count) }
   scope :available_for, ->(count) { post_badges.where("threshold <= ?", count).order(threshold: :desc) }
+
+  scope :sweetness_twin_badges, -> { where(badge_kind: :sweetness_twin) }
 end

--- a/app/models/sweetness_profile.rb
+++ b/app/models/sweetness_profile.rb
@@ -2,13 +2,21 @@ class SweetnessProfile < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :sweetness_type
 
+  scope :near_sweetness_strength, ->(value, range = 1) {
+    min_val = [ value - range, 1 ].max
+    max_val = [ value + range, 5 ].min
+    where(sweetness_strength: min_val..max_val)
+  }
+  scope :near_aftertaste_clarity, ->(value, range = 1) {
+    min_val = [ value - range, 1 ].max
+    max_val = [ value + range, 5 ].min
+    where(aftertaste_clarity: min_val..max_val)
+  }
+
   before_create :generate_token
 
-  def generate_token
-    loop do
-      self.token = SecureRandom.uuid
-      break unless SweetnessProfile.exists?(token: token)
-    end
+  def self.latest_profile(user_id)
+    where(user_id: user_id).order(created_at: :desc).first
   end
 
   def sweetness_kind
@@ -22,5 +30,14 @@ class SweetnessProfile < ApplicationRecord
       }
     )
     diagnoser.send(:diagnose_kind, diagnoser.call[:scores])
+  end
+
+  private
+
+  def generate_token
+    loop do
+      self.token = SecureRandom.uuid
+      break unless SweetnessProfile.exists?(token: token)
+    end
   end
 end

--- a/app/models/sweetness_profile.rb
+++ b/app/models/sweetness_profile.rb
@@ -12,7 +12,7 @@ class SweetnessProfile < ApplicationRecord
   end
 
   def sweetness_kind
-    diagnoser = Diagnosis::SweetnessDiagnoser.new(
+    diagnoser = Diagnosis::SweetnessTypeProcessor.new(
       {
         "sweetness_strength" => sweetness_strength,
         "aftertaste_clarity" => aftertaste_clarity,

--- a/app/services/diagnosis/sweetness_type_processor.rb
+++ b/app/services/diagnosis/sweetness_type_processor.rb
@@ -1,5 +1,5 @@
 module Diagnosis
-  class SweetnessDiagnoser
+  class SweetnessTypeProcessor
     def initialize(answers)
       @answers = answers
     end

--- a/app/services/post_badge.rb
+++ b/app/services/post_badge.rb
@@ -1,4 +1,4 @@
-class BadgeService
+class PostBadge
   # 新しい投稿バッジを付与・DB更新
   def self.check_and_award_post_badges(user)
     post_count = user.posts.count

--- a/app/services/sweetness_twin_badge.rb
+++ b/app/services/sweetness_twin_badge.rb
@@ -1,0 +1,67 @@
+class SweetnessTwinBadge
+  # ログインユーザーと関係するツインのバッジを更新
+  def self.refresh_for(user)
+    return unless user
+    badge = Badge.find_by(badge_kind: :sweetness_twin)
+    return unless badge
+
+    # ログインユーザーの最新プロフィールを取得
+    latest = SweetnessProfile.latest_profile(user.id)
+    return unless latest
+
+    # ツイン判定
+    twin_users = find_twins_for(latest)
+    # バッジ処理
+    ActiveRecord::Base.transaction do
+      # 既存のツインバッジをすべて削除
+      UserBadge.where(badge: badge).delete_all
+      # ツインユーザーに新しくバッジを付与
+      twin_users.each do |twin_user|
+        UserBadge.create!(user: twin_user, badge: badge)
+      end
+    end
+  end
+
+  private
+
+  # ツインユーザー判定
+  def self.find_twins_for(profile)
+    # 各ユーザーの最新プロフィールIDを取得
+    latest_profile_ids = SweetnessProfile
+        .select("MAX(id) as id")
+        .where.not(user_id: profile.user_id)
+        .group(:user_id)
+        .map(&:id)
+    # 必須条件
+    candidate_profiles = SweetnessProfile
+        .includes(:user)
+        .where(id: latest_profile_ids)
+        .near_sweetness_strength(profile.sweetness_strength, 1)
+        .near_aftertaste_clarity(profile.aftertaste_clarity, 1)
+    # 総合スコアとの比較
+    twin_profiles = candidate_profiles.select do |latest_profile|
+      # 全5項目の差分を計算
+      total_score = (profile.sweetness_strength - latest_profile.sweetness_strength).abs +
+                    (profile.aftertaste_clarity - latest_profile.aftertaste_clarity).abs +
+                    (profile.natural_sweetness - latest_profile.natural_sweetness).abs +
+                    (profile.coolness - latest_profile.coolness).abs +
+                    (profile.richness - latest_profile.richness).abs
+      total_score <= 4
+    end
+    twin_users = twin_profiles.map(&:user).uniq
+    twin_users.reject { |user| user.id == profile.user_id }
+  end
+
+  def self.current_twin_badge(user)
+    badge = user.badges.sweetness_twin_badges.first
+    return nil unless badge
+
+    # 最新プロフィールを取得
+    latest = SweetnessProfile.latest_profile(user.id)
+    return nil unless latest
+
+    # ツイン判定（ツインがいる場合のみバッジとして返す）
+    twin_users = find_twins_for(latest)
+    twin_users.any? ? badge : nil
+  end
+end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -20,6 +20,14 @@
               <%= image_tag "trophy.svg" %>
               <%= display_post_badge(post.user) %>
             </span>
+            <% if user_signed_in? %>
+              <% if display_sweetness_twin_badge(post.user) %>
+                <span class="flex flex-row gap-1 text-xs rounded-full px-2 py-1 bg-primary w-fit">
+                  <%= image_tag "handshake.svg", class: "h-5 w-5" %>
+                  <%= display_sweetness_twin_badge(post.user) %>
+                </span>
+              <% end %>
+            <% end %>
           </div>
         <% end %>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -32,6 +32,14 @@
                 <%= image_tag "trophy.svg" %>
                   <%= display_post_badge(@post.user) %>
               </span>
+              <% if user_signed_in? %>
+                <% if display_sweetness_twin_badge(@post.user) %>
+                  <span class="flex flex-row gap-1 text-xs rounded-full px-2 py-1 bg-primary w-fit">
+                    <%= image_tag "handshake.svg", class: "h-5 w-5" %>
+                    <%= display_sweetness_twin_badge(@post.user) %>
+                  </span>
+                <% end %>
+              <% end %>
             </div>
           <% end %>
         </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -123,6 +123,14 @@
                     <%= image_tag "trophy.svg" %>
                     <%= display_post_badge(post.user) %>
                   </span>
+                  <% if user_signed_in? %>
+                    <% if display_sweetness_twin_badge(post.user) %>
+                      <span class="flex flex-row gap-1 text-xs rounded-full px-2 py-1 bg-primary w-fit">
+                        <%= image_tag "handshake.svg", class: "h-5 w-5" %>
+                        <%= display_sweetness_twin_badge(post.user) %>
+                      </span>
+                    <% end %>
+                  <% end %>
                 </div>
               </div>
 

--- a/app/views/shared/_user_profile.html.erb
+++ b/app/views/shared/_user_profile.html.erb
@@ -14,6 +14,14 @@
         <div class="text-lg md:text-xl font-semibold break-words">
           <div class="flex flex-col items-start gap-2">
             <span><%= user.name %></span>
+            <% if user_signed_in? %>
+              <% if display_sweetness_twin_badge(user) %>
+                <span class="flex flex-row gap-1 text-xs rounded-full px-2 py-1 bg-primary w-fit">
+                  <%= image_tag "handshake.svg", class: "h-5 w-5" %>
+                  <%= display_sweetness_twin_badge(user) %>
+                </span>
+              <% end %>
+            <% end %>
             <% if display_post_badge(user).present? %>
               <span class="flex flex-row gap-1 text-xs rounded-full px-2 py-1 bg-success">
                 <%= image_tag "trophy.svg" %>


### PR DESCRIPTION
ユーザー同士の診断結果を比較し、数値が近いユーザーに甘さツインバッジを付与する機能を実装しました。

---

### 📋 機能概要
- バッジ判定・付与ロジックを実装。  
- サービスオブジェクトに切り出して責務を分離
- 表示有無はヘルパーで制御
- ログイン・診断後にメソッドの呼び出しをし、バッジ更新処理をトリガーするように。
- 各画面（投稿・商品・プロフィール）でバッジを表示

### ✅ 確認項目
- [ ] 診断を受けたあと、ツイン判定が正しく動作すること  
- [ ] ログイン/ログアウト時にバッジ表示が意図通りか確認  
- [ ] 投稿詳細・商品詳細・プロフィールでバッジが表示されること
- [ ] 未ログインではツインバッジが表示されていないこと  

---

## 📝 バグ修正
- [ ] 相手が診断した際の自分へのバッジ付与問題 → #166 で対応予定
