### PR TITLE
Feature/#185 chart updates

### DIFF
--- a/app/helpers/chart_helper.rb
+++ b/app/helpers/chart_helper.rb
@@ -1,0 +1,9 @@
+module ChartHelper
+  def sweetness_label(user_post: nil, post: nil)
+    if user_post.present? || (post.present? && current_user == post.user)
+      t("defaults.chart.sweetness_user")
+    else
+      t("defaults.chart.sweetness_other_user")
+    end
+  end
+end

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -97,8 +97,8 @@
 
             <% else %>
               <!-- ログインユーザーは未投稿で他ユーザーの投稿がある場合 -->
-              <%= render "shared/chart/sweetness_posts",
-                chart_id: "radarChart",
+              <%= render "shared/chart/sweetness_average_only",
+                chart_id: "averageChartOnly",
                 data: [
                   @average_scores[:sweetness_strength],
                   @average_scores[:aftertaste_clarity],

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -59,40 +59,58 @@
 
     <% if @posts.present? %>
       <!-- チャート -->
-    <div class="flex justify-center p-2 md:p-4">
-      <div class="w-full max-w-lg sm:max-w-xl lg:max-w-xl p-2 border-secondary rounded-3xl bg-white">
-        <div class="mx-auto w-full max-w-md p-2">
-        <% if user_signed_in? && @user_post.present? %>
-            <%= render "shared/chart/sweetness_average",
-            chart_id: "averageChart",
-            user_data: [
-                @user_post.post_sweetness_score.sweetness_strength,
-                @user_post.post_sweetness_score.aftertaste_clarity,
-                @user_post.post_sweetness_score.natural_sweetness,
-                @user_post.post_sweetness_score.coolness,
-                @user_post.post_sweetness_score.richness
-            ],
-            average_data: [
-                @average_scores[:sweetness_strength],
-                @average_scores[:aftertaste_clarity],
-                @average_scores[:natural_sweetness],
-                @average_scores[:coolness],
-                @average_scores[:richness]
-            ] %>
-        <% else %>
-            <%= render "shared/chart/sweetness_posts",
-            chart_id: "radarChart",
-            data: [
-                @average_scores[:sweetness_strength],
-                @average_scores[:aftertaste_clarity],
-                @average_scores[:natural_sweetness],
-                @average_scores[:coolness],
-                @average_scores[:richness]
-            ] %>
-        <% end %>
+      <div class="flex justify-center p-2 md:p-4">
+        <div class="w-full max-w-lg sm:max-w-xl p-2 border-secondary rounded-3xl bg-white">
+          <div class="mx-auto w-full max-w-md p-2">
+
+            <% if user_signed_in? && @user_post.present? %>
+              <% if @posts.any?(&:user) && @posts.any? { |p| p.user != current_user } %>
+                <!-- ログインユーザーと他ユーザーの投稿がある場合 -->
+                <%= render "shared/chart/sweetness_average",
+                  chart_id: "averageChart",
+                  user_data: [
+                    @user_post.post_sweetness_score.sweetness_strength,
+                    @user_post.post_sweetness_score.aftertaste_clarity,
+                    @user_post.post_sweetness_score.natural_sweetness,
+                    @user_post.post_sweetness_score.coolness,
+                    @user_post.post_sweetness_score.richness
+                  ],
+                  average_data: [
+                    @average_scores[:sweetness_strength],
+                    @average_scores[:aftertaste_clarity],
+                    @average_scores[:natural_sweetness],
+                    @average_scores[:coolness],
+                    @average_scores[:richness]
+                  ] %>
+              <% else %>   
+              <!-- ログインユーザーのみ投稿している場合 -->
+              <%= render "shared/chart/sweetness_posts",
+                chart_id: "radarChart",
+                data: [
+                  @user_post.post_sweetness_score.sweetness_strength,
+                  @user_post.post_sweetness_score.aftertaste_clarity,
+                  @user_post.post_sweetness_score.natural_sweetness,
+                  @user_post.post_sweetness_score.coolness,
+                  @user_post.post_sweetness_score.richness
+                ] %>
+              <% end %>
+
+            <% else %>
+              <!-- ログインユーザーは未投稿で他ユーザーの投稿がある場合 -->
+              <%= render "shared/chart/sweetness_posts",
+                chart_id: "radarChart",
+                data: [
+                  @average_scores[:sweetness_strength],
+                  @average_scores[:aftertaste_clarity],
+                  @average_scores[:natural_sweetness],
+                  @average_scores[:coolness],
+                  @average_scores[:richness]
+                ] %>
+            <% end %>
+
+          </div>
         </div>
       </div>
-    </div>
 
       <!-- ユーザーレビュー -->
       <div class="bg-white px-4 py-6 md:p-2 max-w-2xl mx-auto rounded-4xl flex flex-col items-center">

--- a/app/views/shared/_user_profile.html.erb
+++ b/app/views/shared/_user_profile.html.erb
@@ -53,7 +53,7 @@
         <div class="w-full max-w-md md:max-w-lg p-2 rounded-3xl bg-white">
 
           <div class="flex justify-end text-sm md:text-base font-bold mb-2">
-            <span class="rounded-full bg-secondary text-white px-3 py-2 text-sm md:text-base">
+            <span class="rounded-xl bg-secondary text-white px-3 py-2 text-sm md:text-base">
               <%= I18n.t("enums.sweetness_type.sweetness_kind.#{sweetness_type.sweetness_kind}") %>
             </span>
           </div>
@@ -70,7 +70,7 @@
                 ] %>
           </div>
 
-          <div class="flex justify-end text-xs md:text-sm pb-4 text-gray-300">
+          <div class="flex justify-end text-xs md:text-sm pb-4 text-base-200">
             <%= t('profiles.diagnosis.latest_date') %>：
             <%= l sweetness_profiles.created_at %>
           </div>

--- a/app/views/shared/chart/_sweetness_average.html.erb
+++ b/app/views/shared/chart/_sweetness_average.html.erb
@@ -23,7 +23,9 @@
             backgroundColor: 'rgba(245, 182, 199, 0.4)',
             borderColor: 'rgba(245, 182, 199, 0.6)',
             borderWidth: borderWidth,
-            pointBackgroundColor: 'rgba(245, 182, 199, 0.6)'
+            pointBackgroundColor: 'rgba(245, 182, 199, 0.6)',
+            pointRadius: 4,
+            pointHoverRadius: 4
           },
           {
             label: ["<%= t('defaults.chart.sweetness_average') %>"],
@@ -32,6 +34,8 @@
             borderColor: 'rgba(153, 215, 170, 0.6)',
             borderWidth: borderWidth,
             pointBackgroundColor: 'rgba(153, 215, 170, 0.6)',
+            pointRadius: 4,
+            pointHoverRadius: 4
           }
         ]
       },

--- a/app/views/shared/chart/_sweetness_average.html.erb
+++ b/app/views/shared/chart/_sweetness_average.html.erb
@@ -24,8 +24,8 @@
             borderColor: 'rgba(245, 182, 199, 0.6)',
             borderWidth: borderWidth,
             pointBackgroundColor: 'rgba(245, 182, 199, 0.6)',
-            pointRadius: 4,
-            pointHoverRadius: 4
+            pointRadius: 3,
+            pointHoverRadius: 3
           },
           {
             label: ["<%= t('defaults.chart.sweetness_average') %>"],
@@ -34,8 +34,8 @@
             borderColor: 'rgba(153, 215, 170, 0.6)',
             borderWidth: borderWidth,
             pointBackgroundColor: 'rgba(153, 215, 170, 0.6)',
-            pointRadius: 4,
-            pointHoverRadius: 4
+            pointRadius: 3,
+            pointHoverRadius: 3
           }
         ]
       },

--- a/app/views/shared/chart/_sweetness_average_only.html.erb
+++ b/app/views/shared/chart/_sweetness_average_only.html.erb
@@ -1,8 +1,8 @@
-<canvas id="radarChart" width="400" height="400"></canvas>
+<canvas id="averageChartOnly" width="400" height="400"></canvas>
 
 <script>
   document.addEventListener("turbo:load", function () {
-    const ctx = document.getElementById("radarChart");
+    const ctx = document.getElementById("averageChartOnly");
     if (!ctx) return;
 
     if (Chart.getChart(ctx)) {
@@ -11,20 +11,17 @@
 
     const borderWidth = window.innerWidth < 768 ? 2 : 4;
 
-    // ユーザーによってラベルを切り替え
-    const labelText = "<%= j sweetness_label(user_post: @user_post, post: @post) %>";
-
     new Chart(ctx, {
       type: 'radar',
       data: {
         labels: ["甘みの強さ", ["後味のキレ/","スッキリ感"], "自然な甘さ", "爽快感", "甘さの深み/コク"],
         datasets: [{
-          label: labelText,
+          label: ["<%= t('defaults.chart.sweetness_average') %>"],
           data: [<%= data.map(&:to_i).join(", ") %>],
-          backgroundColor: 'rgba(245, 182, 199, 0.4)',
-          borderColor: 'rgba(245, 182, 199, 0.6)',
+          backgroundColor: 'rgba(153, 215, 170, 0.4)',
+          borderColor: 'rgba(153, 215, 170, 0.6)',
           borderWidth: borderWidth,
-          pointBackgroundColor: 'rgba(245, 182, 199, 0.6)',
+          pointBackgroundColor: 'rgba(153, 215, 170, 0.6)',
           pointRadius: 3,
           pointHoverRadius: 3
         }]

--- a/app/views/shared/chart/_sweetness_posts.html.erb
+++ b/app/views/shared/chart/_sweetness_posts.html.erb
@@ -10,17 +10,23 @@
     }
 
     const borderWidth = window.innerWidth < 768 ? 2 : 4;
+
+    // ユーザーによってラベルを切り替え
+    const labelText = "<%= current_user == @post&.user ? t('defaults.chart.sweetness_user') : t('defaults.chart.sweetness_other_user') %>";
+
     new Chart(ctx, {
       type: 'radar',
       data: {
         labels: ["甘みの強さ", ["後味のキレ/","スッキリ感"], "自然な甘さ", "爽快感", "甘さの深み/コク"],
         datasets: [{
-          label: ["<%= t('defaults.chart.sweetness_user') %>"],
+          label: labelText,
           data: [<%= data.map(&:to_i).join(", ") %>],
           backgroundColor: 'rgba(245, 182, 199, 0.4)',
           borderColor: 'rgba(245, 182, 199, 0.6)',
           borderWidth: borderWidth,
-          pointBackgroundColor: 'rgba(245, 182, 199, 0.6)'
+          pointBackgroundColor: 'rgba(245, 182, 199, 0.6)',
+          pointRadius: 4,
+          pointHoverRadius: 4
         }]
       },
       options: {

--- a/app/views/shared/chart/_sweetness_profile_chart.html.erb
+++ b/app/views/shared/chart/_sweetness_profile_chart.html.erb
@@ -20,7 +20,9 @@
           backgroundColor: 'rgba(144, 173, 220, 0.4)',
           borderColor: 'rgba(144, 173, 220, 0.6)',
           borderWidth: borderWidth,
-          pointBackgroundColor: 'rgba(144, 173, 220, 0.6)'
+          pointBackgroundColor: 'rgba(144, 173, 220, 0.6)',
+          pointRadius: 4,
+          pointHoverRadius: 4
         }]
       },
       options: {

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -31,6 +31,7 @@ ja:
       sweetness_profile: 好みの甘さ感覚
       sweetness_user: あなたの評価
       sweetness_average: みんなの評価
+      sweetness_other_user: ユーザーの評価
     badge_modal:
       title: あなたの称号が変わりました。
       message: "『%{badge_name}』"


### PR DESCRIPTION
## 概要
投稿・商品詳細画面で表示される Sweetnessチャートの描画ロジックを整理 し、条件分岐を統一しました。また、マイページ内チャートのUIを改善しました。

---

### 📋 実装内容
- **チャート描画ロジックの整理**
  - ログインユーザーのみの評価、ログインユーザー＋他ユーザーの平均評価、他ユーザーのみの平均評価の条件分岐を整理
  - i18nの追記でチャートのタイトルから内容が読み取れるように
 - **チャートのUIの改善**
  - pointRadiusのサイズ指定
  - チャート内日付のフォントカラー・ 甘さタイプのUI修正
- 新規追加
  - 平均のみ表示用パーシャル `_sweetness_average_only.html.erb` の作成
  - チャートタイトル用ヘルパー` ChartHelper#sweetness_label `の追加

---

### ✅ 確認事項
- [ ] 投稿詳細・商品詳細画面でログインユーザーの評価と平均評価が正しく条件分岐して表示されるか
- [ ] チャート内の pointRadius や pointHoverRadius が反映され、UIが崩れていないか
- [ ] マイページ内チャートのタイトルや甘さタイプの表示が意図通りか

close #185 