### PR TITLE
Fix/#187 post new redirect bug

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,7 +17,7 @@ class PostsController < ApplicationController
     @post = Post.new
     if params[:product_id].present?
       # 既存商品へのレビュー
-      @post.product = Product.find(params[:product_id], items: 10)
+      @post.product = Product.find(params[:product_id])
       @post.build_post_sweetness_score
     else
       # 新規商品登録と同時レビュー

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -96,7 +96,7 @@
                                 <%= hover_colors[rating_key] %>
                                 peer-checked:bg-<%= selected_colors[rating_key].split('-').last %> 
                                 <%= 'bg-' + selected_colors[rating_key].split('-').last if checked %>">
-                      <%= image_tag rating_images[rating_key], class: "w-7 h-7 md:w-8 md:h-8 pointer-events-none" %>
+                      <%= image_tag rating_images[rating_key], class: "w-8 h-8 pointer-events-none" %>
                     </span>
                   </label>
                 <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,5 +1,5 @@
 <div class="p-1 md:p-4">
-  <div class="flex flex-col p-2 items-center justify-center w-full max-w-3xl mx-auto bg-base-200 rounded-4xl">
+  <div class="flex flex-col p-2 items-center justify-center w-full max-w-3xl mx-auto bg-base-100 rounded-4xl">
     <h1 class="text-center text-xl md:text-2xl p-4 border-b border-base-200 w-full">
       <%= t('.title') %></h1>
    <%= render 'form', post: @post %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,7 +1,7 @@
 <div class="p-2 md:p-4">
   <div class="p-2 w-full max-w-3xl mx-auto bg-base-100 rounded-4xl">
     <h1 class="flex justify-between items-center text-xl md:text-2xl p-4 border-b border-base-200 w-full">
-      <span class="text-center flex-1"><%= t('.title') %></span>
+      <span class="text-center flex-1"><%= @product.name %></span>
       <% if user_signed_in? %>
         <%= render 'bookmark_buttons', { product: @product } %>
       <% end %>


### PR DESCRIPTION
## 概要
商品指定ありの投稿作成画面に遷移できないバグを修正しました。また、関連ビューのUI微調整も行っています。

---

### 📋 バックエンド
- **PostsController#new**  
  - 不要な `params` を削除して、既存商品指定時にトップページへリダイレクトされてしまう問題を解消

### 🎨 フロントエンド（UI微修正）
- **app/views/posts/new.html.erb**  
  - 背景色の修正
- **app/views/posts/_search_form.html.erb**  
  - 検索フォーム内アイコンのサイズ変更
- **app/views/products/show.html.erb**  
  - 商品詳細表示のレイアウト微調整

---

###  修正前の挙動
- 投稿作成画面で商品を指定するとトップページにリダイレクトされる

### 修正後の挙動
- 商品指定ありでも投稿作成画面に遷移可能
- 原因: pagy 実装時にPostsController#newに不要なparamsを渡していた。
  引数を修正しバグを解消。

### ✅ 確認事項
- [ ] トップページから「投稿」ボタン（既存商品指定）をクリックすると、投稿作成画面に遷移すること
- [ ] 遷移先で正しい商品情報がフォームにセットされていること
- [ ] 投稿フォーム・検索フォーム・商品詳細画面のレイアウトが崩れていないこと
- [ ] 未ログインで投稿ボタンを押すとログインページにリダイレクトされること

close #187  