### PR TITLE
Feat/#48 posts comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,38 @@
+class CommentsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_post, only: %i[create]
+
+  def create
+    @comment = current_user.comments.build(comment_params)
+    if @comment.save
+      respond_to do |format|
+        format.html { redirect_to @post }
+        format.turbo_stream
+      end
+    else
+      respond_to do |format|
+        format.html { redirect_to @post, status: :unprocessable_entity }
+        format.turbo_stream
+      end
+    end
+  end
+
+  def destroy
+    @comment = current_user.comments.find(params[:id])
+    @comment.destroy!
+    respond_to do |format|
+      format.html { redirect_to @post }
+      format.turbo_stream
+    end
+  end
+
+  private
+
+  def set_post
+    @post = Post.find(params[:post_id])
+  end
+
+  def comment_params
+    params.require(:comment).permit(:body).merge(post_id: params[:post_id])
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -57,6 +57,8 @@ class PostsController < ApplicationController
 
   def show
     @post = Post.find(params[:id]).decorate
+    @comment = Comment.new
+    @comments = @post.comments.includes(:user).order(created_at: :desc)
   end
 
   def destroy

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,7 @@
 
 import { application } from "./application"
 import FadeController from "./fade_controller"
+import ResetFormController from "./reset_form_controller"
 
 application.register("fade", FadeController)
+application.register("reset-form", ResetFormController)

--- a/app/javascript/controllers/reset_form_controller.js
+++ b/app/javascript/controllers/reset_form_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  reset() {
+    this.element.reset()
+  }
+}

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ApplicationRecord
+  validates :body, presence: true, length: { maximum: 65_535 }
+
+  belongs_to :user
+  belongs_to :post
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -11,6 +11,7 @@ class Post < ApplicationRecord
   has_one :category, through: :product
   has_one :post_sweetness_score, dependent: :destroy
   has_many :likes, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   accepts_nested_attributes_for :product, update_only: true
   accepts_nested_attributes_for :post_sweetness_score

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,8 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :like_posts, through: :likes, source: :post
+  has_many :comments, dependent: :destroy
+  has_many :comment_posts, through: :comments, source: :post
   has_many :bookmarks, dependent: :destroy
   has_many :bookmark_products, through: :bookmarks, source: :product
   has_many :user_badges, dependent: :destroy

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,23 @@
+<%= turbo_frame_tag dom_id(comment) do %>
+  <div class="w-full border-b border-base-200 px-1 sm:px-4 py-3 text-neutral">
+    <div class="flex flex-row items-center justify-between mb-1">
+      <div class="flex items-center gap-2">
+        <%= comment.user.decorate.avatar_image(class: "w-9, h-9") %>
+        <span class="font-medium text-xs"><%= comment.user.name %></span>
+      </div>
+       <% if user_signed_in? && current_user == comment.user %>
+       <%= link_to t('helpers.submit.delete'),
+          comment_path(comment),
+          class: "btn btn-sm",
+          data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } %>
+      <% end %>
+    </div>
+
+    <div class="text-sm leading-relaxed">
+      <%= comment.body %>
+    </div>
+      <div class="flex justify-end text-sm mt-1">
+        <time class="text-xs text-base-300"><%= l comment.created_at %></time>
+      </div>
+  </div>
+<% end %>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,0 +1,15 @@
+<!-- 現在は発動しない -->
+<% if @comment.errors.any? %>
+  <%= turbo_stream.replace "new_comment" do %>
+    <%= render "posts/comment_form", post: @post, comment: @comment %>
+  <% end %>
+<% else %>
+  <!-- 現在動作している部分 -->
+  <%= turbo_stream.prepend "comments" do %>
+    <%= render @comment %>
+  <% end %>
+
+  <%= turbo_stream.replace "new_comment" do %>
+    <%= render "posts/comment_form", post: @post, comment: Comment.new %>
+  <% end %>
+<% end %>

--- a/app/views/comments/destroy.turbo_stream.erb
+++ b/app/views/comments/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove dom_id(@comment) %>

--- a/app/views/posts/_comment_form.html.erb
+++ b/app/views/posts/_comment_form.html.erb
@@ -1,0 +1,25 @@
+<!-- 現在は発動しない -->
+<% if comment.errors.any? %>
+  <div class="error-messages w-fit text-error bg-base-100 p-2 rounded-4xl ring-2 ring-error">
+    <ul>
+      <% comment.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+<!-- 現在動作している部分 -->
+<%= form_with(
+      url: post_comments_path(post),
+      model: comment,
+      data: { controller: "reset-form", action: "turbo:submit-end->reset-form#reset" },
+      class: "flex items-center gap-2 w-full",
+    ) do |f| %>
+
+  <div class="flex-grow p-2">
+    <%= f.text_field :body,
+      placeholder: t('defaults.placeholders.new_comment'),
+      class: "w-full rounded-full border border-base-200 px-4 py-2 text-sm bg-white" %>
+  </div>
+  <%= f.submit t('helpers.submit.send'), class: "text-sm btn btn-success text-base-300" %>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -105,7 +105,7 @@
 
     <!-- レビューセクション -->
     <div class="p-2 md:p-4">
-      <div class="p-2 w-full max-w-xl mx-auto bg-white rounded-4xl">
+      <div class="p-2 w-full max-w-xl mx-auto bg-white rounded-4xl mb-6">
         <div class="text-center text-xl p-2 text-neutral">
           レビュー
         </div>
@@ -120,11 +120,8 @@
               <div class="mb-3 text-base-200">レビューがありません</div>
             <% end %>
           </div>
+          <!-- いいね -->
           <div class="flex flex-row pt-2 text-sm gap-6 md:gap-30 text-base-200">
-            <span class="flex items-center gap-1">
-              <%= image_tag "chat.svg", class: "h-6 w-6" %>
-              コメントする
-            </span>
             <span class="flex items-center gap-1">
             <% if user_signed_in? %>
               <%= render 'like_buttons', { post: @post } %>
@@ -136,9 +133,18 @@
             <% end %>
             </span>
           </div>
-          <div class="text-sm text-center text-error">
-            ※ 準備中
+        </div>
+      </div>
+      <div class="w-full max-w-xl mx-auto rounded-4xl p-3">
+        <% if user_signed_in? %>
+          <!-- コメントフォーム -->
+          <div id="new_comment">
+            <%= render "posts/comment_form", post: @post, comment: Comment.new %>
           </div>
+        <% end %>
+        <!-- コメント一覧 -->
+        <div id="comments" class="mt-4">
+          <%= render @comments %>
         </div>
       </div>
     </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -9,6 +9,7 @@ ja:
       bookmark: ブックマーク
       badge: バッジ
       like: いいね
+      comment: コメント
     attributes:
       sweetness_strength: 甘みの強さ
       aftertaste_clarity: 後味のキレ/スッキリ感
@@ -37,6 +38,8 @@ ja:
         image: 商品の画像
         category_id: カテゴリ
         manufacturer: メーカー
+      comment:
+        body: コメント
   enums:
     sweetness_type:
       sweetness_kind:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -5,6 +5,7 @@ ja:
     placeholders:
       search_word: キーワードを入力
       search_products: 商品名を入力
+      new_comment: コメントを書く...
     select:
       manufacturer: メーカーを選択
       category: カテゴリを選択
@@ -58,6 +59,7 @@ ja:
       search: 検索
       clear: クリア
       post: 投稿する
+      send: 送信
   shared:
       header:
         login: ログイン

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,9 @@ Rails.application.routes.draw do
   resources :diagnoses, only: %i[new create]
   get "diagnoses/result/:token", to: "diagnoses#show", as: :diagnosis_result
 
-  resources :posts
+  resources :posts do
+    resources :comments, only: %i[create destroy], shallow: true
+  end
 
   resources :likes, only: %i[create destroy]
 

--- a/db/migrate/20250924035410_create_comments.rb
+++ b/db/migrate/20250924035410_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[7.2]
+  def change
+    create_table :comments do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+      t.text :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_23_101021) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_24_035410) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -69,6 +69,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_23_101021) do
     t.datetime "updated_at", null: false
     t.string "slug", null: false
     t.index ["slug"], name: "index_categories_on_slug", unique: true
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "likes", force: :cascade do |t|
@@ -180,6 +190,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_23_101021) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "bookmarks", "products"
   add_foreign_key "bookmarks", "users"
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
   add_foreign_key "post_sweetness_scores", "posts"

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  id: 1
+  user_id: 1
+  post_id: 1
+  body: MyText
+
+two:
+  id: 2
+  user_id: 2
+  post_id: 2
+  body: MyText

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
投稿に対するコメント機能を実装しました。
投稿詳細画面でコメントの投稿・削除が可能です。

### 📋 機能実装
- コメント機能を追加  
  - Commentモデル・テーブルの作成  
  - Turbo Stream 対応のビュー追加
- User / Postモデルに関連付けを追加 
- i18n の日本語ファイル（`activerecord/ja.yml`）を追記 

### ✅ 確認項目
- [ ]  コメント投稿後、コメントフォームは空の状態になること。
- [ ]  コメントは新しいものから上から順に表示されること。
- [ ]   自分が投稿したコメントのみ、削除ボタンが表示されること。
- [ ]   コメントの削除ボタンを押すと、「削除しますか？」と確認が表示されること。
- [ ]  コメントを削除できること。
- [ ]  投稿時、削除時のフラッシュメッセージは表示されないこと。

### 📝 今後実装予定
- バリデーションエラーメッセージの表示

close #48 