### PR TITLE
Feat/#50 notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ erDiagram
         int recipient_id FK "通知を受け取るユーザー"
         int notifiable_id "対象のいいね/コメントのID"
         string notifiable_type "通知対象のモデル名（Like/Comment）"
-        string action "通知アクション（liked/commented）"
+        int action "通知アクション（liked/commented）"
         bool checked "既読の確認（default false）"
         datetime created_at "作成日時" 
         datetime updated_at "更新日時"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_unchecked_notifications_count
   allow_browser versions: :modern
 
   rescue_from ActiveRecord::RecordNotFound do |exception|
@@ -12,5 +13,13 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :role ])
     devise_parameter_sanitizer.permit(:account_update, keys: [ :role ])
+  end
+
+  private
+
+  def set_unchecked_notifications_count
+    if user_signed_in?
+      @unchecked_notifications_count = current_user.received_notifications.unchecked.count
+    end
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,37 @@
+class NotificationsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @notifications = current_user.received_notifications
+                                 .includes(:sender, :notifiable)
+                                 .order(created_at: :desc)
+    @pagy, @notifications = pagy(@notifications, limit: 15)
+  end
+
+  def update
+    notification = current_user.received_notifications.find(params[:id])
+    notification.update!(checked: true)
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html do
+        # 通知の対象へリダイレクト
+        case notification.notifiable_type
+        when "Like", "Comment"
+          redirect_to post_path(notification.notifiable.post)
+        else
+          redirect_to notifications_path
+        end
+      end
+    end
+  end
+
+  def mark_all_as_read
+    current_user.received_notifications.unchecked.update_all(checked: true)
+    @notifications = current_user.received_notifications.order(created_at: :desc)
+    respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to notifications_path }
+    end
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -59,6 +59,15 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id]).decorate
     @comment = Comment.new
     @comments = @post.comments.includes(:user).order(created_at: :desc)
+
+    # 通知画面から投稿詳細画面へ遷移した時に既読処理
+    if params[:notification_id].present?
+      notification = Notification.find(params[:notification_id])
+      if notification.recipient_id != current_user.id
+        redirect_to notifications_path, alert: "不正なアクセスです" and return
+      end
+      notification.update(checked: true)
+    end
   end
 
   def destroy

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,0 +1,5 @@
+module NotificationsHelper
+  def notification_text_class(notification)
+    notification.checked ? "text-base-200" : "text-neutral"
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,4 +3,25 @@ class Comment < ApplicationRecord
 
   belongs_to :user
   belongs_to :post
+  has_many :notifications, as: :notifiable, dependent: :destroy
+
+  after_create_commit :create_comment_notification
+
+  def create_comment_notification
+    return if self.user_id == self.post.user_id
+
+    unless Notification.exists?(
+        sender_id: self.user_id,
+        recipient_id: self.post.user_id,
+        notifiable: self,
+        action: :commented
+    )
+    Notification.create(
+        sender_id: self.user_id,
+        recipient_id: self.post.user_id,
+        notifiable: self,
+        action: :commented
+    )
+    end
+  end
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -3,4 +3,25 @@ class Like < ApplicationRecord
 
   belongs_to :user
   belongs_to :post
+  has_many :notifications, as: :notifiable, dependent: :destroy
+
+  after_create_commit :create_liked_notification
+
+  def create_liked_notification
+    return if self.user_id == self.post.user_id
+
+    unless Notification.exists?(
+        sender_id: self.user_id,
+        recipient_id: self.post.user_id,
+        notifiable: self,
+        action: :liked
+    )
+    Notification.create(
+        sender_id: self.user_id,
+        recipient_id: self.post.user_id,
+        notifiable: self,
+        action: :liked
+    )
+    end
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,11 @@
+class Notification < ApplicationRecord
+  validates :action, presence: true
+  validates :checked, inclusion: { in: [ true, false ] }
+
+  belongs_to :sender, class_name: "User", foreign_key: "sender_id"
+  belongs_to :recipient, class_name: "User", foreign_key: "recipient_id"
+  belongs_to :notifiable, polymorphic: true
+
+  enum :action, { liked: 0, commented: 1 }
+  scope :unchecked, -> { where(checked: false) }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,9 @@ class User < ApplicationRecord
   has_many :badges, through: :user_badges
   has_many :sweetness_twins, dependent: :destroy
   has_many :twin_users, through: :sweetness_twins, source: :twin_user
+  has_many :sent_notifications, class_name: "Notification", foreign_key: "sender_id", dependent: :destroy
+  has_many :received_notifications, class_name: "Notification", foreign_key: "recipient_id", dependent: :destroy
+  has_many :notifications, as: :notifiable, dependent: :destroy
 
   enum :role, { general: 0, admin: 1 }
 

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,0 +1,45 @@
+<%= turbo_frame_tag dom_id(notification) do %>
+  <div class="block w-full border-b border-base-200 px-1 sm:px-4 py-3 hover:bg-base-100">
+    <div class="flex flex-row items-start gap-2 mb-1">
+      <!-- アイコン -->
+      <div class="flex-shrink-0">
+        <%= link_to user_path(notification.sender, notification_id: notification.id),
+                    class: "hover:opacity-80", data: { turbo_frame: "_top" } do %>
+          <%= notification.sender.decorate.avatar_image(class: "w-8 h-8 md:w-9 md:h-9") %>
+        <% end %>
+      </div>
+
+      <!-- 通知文 -->
+      <div class="flex-1 text-xs md:text-sm md:mt-2 leading-relaxed <%= notification_text_class(notification) %>">
+        <span>
+          <%= link_to notification.sender.name,
+                      user_path(notification.sender, notification_id: notification.id),
+                      class: "hover:opacity-80", data: { turbo_frame: "_top" } %>
+        </span>
+        さんが
+        <% if notification.notifiable_type == "Like" && notification.notifiable&.post %>
+          あなたの投稿「
+          <%= link_to notification.notifiable.post.product.name,
+                      post_path(notification.notifiable.post, notification_id: notification.id),
+                      class: "underline hover:opacity-80", data: { turbo_frame: "_top" } %>
+          」にいいねしました。
+        <% elsif notification.notifiable_type == "Comment" && notification.notifiable&.post %>
+          あなたの投稿「
+          <%= link_to notification.notifiable.post.product.name,
+                      post_path(notification.notifiable.post, notification_id: notification.id),
+                      class: "underline hover:opacity-80", data: { turbo_frame: "_top" } %>
+          」にコメントしました。
+        <% else %>
+          <%= t('.no_posts') %>
+        <% end %>
+      </div>
+    </div>
+
+    <!-- 作成日時 -->
+    <div class="flex justify-end text-sm mt-1">
+      <time class="text-xs text-base-300">
+        <%= l notification.created_at, format: "%-m月%-d日 %H:%M" %>
+      </time>
+    </div>
+  </div>
+<% end %>

--- a/app/views/notifications/create.turbo_stream.erb
+++ b/app/views/notifications/create.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.replace "notification-badge" do %>
+  <%= render "shared/notification_badge" %>
+<% end %>
+
+<%= turbo_stream.prepend "notifications", partial: "notifications/notification", locals: { notification: @notification } %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,0 +1,30 @@
+<div class="p-1 md:p-4">
+  <div class="flex flex-col p-1 items-center justify-center w-full max-w-2xl mx-auto bg-base-100 rounded-4xl">
+    <h1 class="text-center text-base md:text-xl p-2 md:p-4 border-b border-base-200 w-full">
+      <%= t('.title') %>
+    </h1>
+
+    <% if @notifications.present? %>
+    <div class="flex flex-col items-center max-w-2xl p-1 md:py-2 md:px-15">
+      <div class="flex flex-col w-full items-end p-1">
+        <%= link_to "すべて既読",
+            mark_all_as_read_notifications_path,
+            data: { turbo_method: :patch, turbo_frame: "_top" },
+            class: "btn btn-sm btn-outline btn-secondary" %>
+      </div>
+      <div id="notifications-list">
+        <%= render @notifications %>
+      </div>
+      </div>
+      <div class="m-4">
+        <%== pagy_nav(@pagy) %>
+      </div>
+    <% else %>
+      <div class="p-4 text-xs md:text-sm">
+        <%= t('.no_notifications') %>
+      </div>
+    </div>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/notifications/mark_all_as_read.turbo_stream.erb
+++ b/app/views/notifications/mark_all_as_read.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.replace "notifications-list" do %>
+  <%= render @notifications %>
+<% end %>
+
+<%= turbo_stream.replace "notification-badge" do %>
+  <%= render "shared/notification_badge" %>
+<% end %>

--- a/app/views/notifications/update_all.turbo_stream.erb
+++ b/app/views/notifications/update_all.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.replace dom_id(@notification) do %>
+  <%= render @notification %>
+<% end %>
+
+<%= turbo_stream.replace "notification-badge" do %>
+  <%= render "shared/notification_badge" %>
+<% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -18,9 +18,11 @@
       </span>
     <% end %>
 
-   <%= link_to "#", class: "flex flex-col items-center justify-center leading-none opacity-60" do %>
+    <%= link_to notifications_path,
+        class: "flex flex-col items-center justify-center leading-none md:hover:bg-[var(--color-base-400)] relative" do %>
       <span class="p-2">
-      <%= image_tag "footer/bell.svg", class: "h-7 w-7 md:h-8 md:w-8" %>
+        <%= render "shared/notification_badge" %>
+        <%= image_tag "footer/bell.svg", class: "h-7 w-7 md:h-8 md:w-8" %>
       </span>
     <% end %>
 

--- a/app/views/shared/_notification_badge.html.erb
+++ b/app/views/shared/_notification_badge.html.erb
@@ -1,0 +1,5 @@
+<div id="notification-badge" class="absolute top-0 sm:top-1 right-3 sm:right-10">
+  <% if @unchecked_notifications_count.to_i > 0 %>
+    <div class="status status-accent animate-bounce"></div>
+  <% end %>
+</div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -10,6 +10,7 @@ ja:
       badge: バッジ
       like: いいね
       comment: コメント
+      notification: 通知
     attributes:
       sweetness_strength: 甘みの強さ
       aftertaste_clarity: 後味のキレ/スッキリ感

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -189,6 +189,11 @@ ja:
       title: あまピタ評価する商品を選択
       product_not_found: 商品が見つかりませんでした
       product_register_suggestion: 商品が見つからない場合、<br>君のあまピタ評価を登録してみよう！
+  notifications:
+    index:
+      title: 通知
+      no_notifications: 通知がありません
+      no_posts: 投稿は削除されています 
   time:
     formats:
       default: "%Y年%m月%d日"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,12 @@ Rails.application.routes.draw do
 
   resources :likes, only: %i[create destroy]
 
+  resources :notifications, only: %i[index update] do
+    collection do
+      patch :mark_all_as_read
+    end
+  end
+
   resources :products, only: %i[index show]
 
   resources :bookmarks, only: %i[create destroy]

--- a/db/migrate/20250925044249_create_notifications.rb
+++ b/db/migrate/20250925044249_create_notifications.rb
@@ -1,0 +1,14 @@
+class CreateNotifications < ActiveRecord::Migration[7.2]
+  def change
+    create_table :notifications do |t|
+      t.references :sender, null: false, foreign_key: { to_table: :users }
+      t.references :recipient, null: false, foreign_key: { to_table: :users }
+      t.references :notifiable, polymorphic: true, null: false
+      t.integer :action, null: false
+      t.boolean :checked, null: false, default: false
+
+      t.timestamps
+    end
+    add_index :notifications, [ :recipient_id, :checked ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_24_035410) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_25_044249) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -89,6 +89,21 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_24_035410) do
     t.index ["post_id"], name: "index_likes_on_post_id"
     t.index ["user_id", "post_id"], name: "index_likes_on_user_id_and_post_id", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "sender_id", null: false
+    t.bigint "recipient_id", null: false
+    t.string "notifiable_type", null: false
+    t.bigint "notifiable_id", null: false
+    t.integer "action", null: false
+    t.boolean "checked", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable"
+    t.index ["recipient_id", "checked"], name: "index_notifications_on_recipient_id_and_checked"
+    t.index ["recipient_id"], name: "index_notifications_on_recipient_id"
+    t.index ["sender_id"], name: "index_notifications_on_sender_id"
   end
 
   create_table "post_sweetness_scores", force: :cascade do |t|
@@ -194,6 +209,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_24_035410) do
   add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
+  add_foreign_key "notifications", "users", column: "recipient_id"
+  add_foreign_key "notifications", "users", column: "sender_id"
   add_foreign_key "post_sweetness_scores", "posts"
   add_foreign_key "posts", "products"
   add_foreign_key "posts", "users"

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NotificationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  id: 1
+  sender_id: 1
+  recipient_id: 1
+  notifiable_id: 1
+  notifiable_type: Comment
+  action: 0
+  checked: false
+
+two:
+  id: 2
+  sender_id: 2
+  recipient_id: 2
+  notifiable_id: 2
+  notifiable_type: Like
+  action: 1
+  checked: false

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NotificationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
通知機能を追加しました。  
ユーザーは自分の投稿に対する「いいね」や「コメント」の通知を確認でき、既読・未読の管理が可能です。  

### 📋 機能実装
- 通知機能を追加  
  - Notificationモデル・テーブルの作成  
  - NotificationController、Turbo Stream 対応のビュー追加
  - 「すべて既読」ボタンで即座に通知バッジを更新
- 投稿詳細・ユーザー詳細画面から通知の既読更新対応
- User / Post / Comment / Likeモデルに関連付けを追加
- i18n の日本語ファイル（`activerecord/ja.yml`、`views/ja.yml`）を追記


### ✅ 確認項目
- [ ] 通知一覧画面で未読通知がバッジ表示されること
- [ ] 通知内のリンクをクリックすると投稿詳細に遷移すること
- [ ]  「すべて既読」ボタンを押すと即座に通知バッジと通知一覧が更新されること
- [ ]  他ユーザーの通知対象の投稿にアクセスできないこと

### 📝 今後実装予定
- ユーザー詳細画面への遷移
- 戻るボタンで既読になるように

close #50
