### PR TITLE
通知一覧の既読処理をリロード方式に変更し、Turbo Stream 関連ファイルを削除

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -9,29 +9,13 @@ class NotificationsController < ApplicationController
   end
 
   def update
-    notification = current_user.received_notifications.find(params[:id])
-    notification.update!(checked: true)
-
-    respond_to do |format|
-      format.turbo_stream
-      format.html do
-        # 通知の対象へリダイレクト
-        case notification.notifiable_type
-        when "Like", "Comment"
-          redirect_to post_path(notification.notifiable.post)
-        else
-          redirect_to notifications_path
-        end
-      end
-    end
+    @notification = current_user.received_notifications.find(params[:id])
+    @notification.update!(checked: true)
+    redirect_to post_path(@notification.notifiable.post)
   end
 
   def mark_all_as_read
-    current_user.received_notifications.unchecked.update_all(checked: true)
-    @notifications = current_user.received_notifications.order(created_at: :desc)
-    respond_to do |format|
-        format.turbo_stream
-        format.html { redirect_to notifications_path }
-    end
+    current_user.received_notifications.unchecked.update(checked: true)
+    redirect_to notifications_path
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -60,13 +60,12 @@ class PostsController < ApplicationController
     @comment = Comment.new
     @comments = @post.comments.includes(:user).order(created_at: :desc)
 
-    # 通知画面から投稿詳細画面へ遷移した時に既読処理
+    # 他ユーザーが通知URLの直打ちで通知対象を閲覧できないように
     if params[:notification_id].present?
       notification = Notification.find(params[:notification_id])
       if notification.recipient_id != current_user.id
-        redirect_to notifications_path, alert: "不正なアクセスです" and return
+        redirect_to notifications_path, alert: "無効なURLです" and return
       end
-      notification.update(checked: true)
     end
   end
 

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,5 +1,5 @@
 module NotificationsHelper
   def notification_text_class(notification)
-    notification.checked ? "text-base-200" : "text-neutral"
+    notification.checked ? "text-stone-400" : "text-neutral"
   end
 end

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,45 +1,30 @@
-<%= turbo_frame_tag dom_id(notification) do %>
-  <div class="block w-full border-b border-base-200 px-1 sm:px-4 py-3 hover:bg-base-100">
-    <div class="flex flex-row items-start gap-2 mb-1">
-      <!-- アイコン -->
-      <div class="flex-shrink-0">
-        <%= link_to user_path(notification.sender, notification_id: notification.id),
-                    class: "hover:opacity-80", data: { turbo_frame: "_top" } do %>
-          <%= notification.sender.decorate.avatar_image(class: "w-8 h-8 md:w-9 md:h-9") %>
-        <% end %>
-      </div>
-
-      <!-- 通知文 -->
-      <div class="flex-1 text-xs md:text-sm md:mt-2 leading-relaxed <%= notification_text_class(notification) %>">
-        <span>
-          <%= link_to notification.sender.name,
-                      user_path(notification.sender, notification_id: notification.id),
-                      class: "hover:opacity-80", data: { turbo_frame: "_top" } %>
-        </span>
-        さんが
-        <% if notification.notifiable_type == "Like" && notification.notifiable&.post %>
-          あなたの投稿「
-          <%= link_to notification.notifiable.post.product.name,
-                      post_path(notification.notifiable.post, notification_id: notification.id),
-                      class: "underline hover:opacity-80", data: { turbo_frame: "_top" } %>
-          」にいいねしました。
-        <% elsif notification.notifiable_type == "Comment" && notification.notifiable&.post %>
-          あなたの投稿「
-          <%= link_to notification.notifiable.post.product.name,
-                      post_path(notification.notifiable.post, notification_id: notification.id),
-                      class: "underline hover:opacity-80", data: { turbo_frame: "_top" } %>
-          」にコメントしました。
-        <% else %>
-          <%= t('.no_posts') %>
-        <% end %>
-      </div>
+<%= link_to notification_path(notification),
+            data: { turbo_method: :patch },
+            class: "block w-full border-b border-base-200 px-1 sm:px-4 py-3 hover:opacity-80" do %>
+  <div class="flex flex-row items-start gap-2 mb-1">
+    <!-- アイコン -->
+    <div class="flex-shrink-0">
+      <%= notification.sender.decorate.avatar_image(class: "w-8 h-8 md:w-9 md:h-9") %>
     </div>
 
-    <!-- 作成日時 -->
-    <div class="flex justify-end text-sm mt-1">
-      <time class="text-xs text-base-300">
-        <%= l notification.created_at, format: "%-m月%-d日 %H:%M" %>
-      </time>
+    <!-- 通知文 -->
+    <div class="flex-1 text-xs md:text-sm md:mt-2 leading-relaxed <%= notification_text_class(notification) %>">
+      <span><%= notification.sender.name %></span>
+      さんが
+      <% if notification.notifiable_type == "Like" && notification.notifiable&.post %>
+        あなたの投稿「<%= notification.notifiable.post.product.name %>」にいいねしました。
+      <% elsif notification.notifiable_type == "Comment" && notification.notifiable&.post %>
+        あなたの投稿「<%= notification.notifiable.post.product.name %>」にコメントしました。
+      <% else %>
+        <%= t('.no_posts') %>
+      <% end %>
     </div>
+  </div>
+
+  <!-- 作成日時 -->
+  <div class="flex justify-end text-sm mt-1 <%= notification_text_class(notification) %>">
+    <time class="text-xs">
+      <%= l notification.created_at, format: "%-m月%-d日 %H:%M" %>
+    </time>
   </div>
 <% end %>

--- a/app/views/notifications/create.turbo_stream.erb
+++ b/app/views/notifications/create.turbo_stream.erb
@@ -1,5 +1,0 @@
-<%= turbo_stream.replace "notification-badge" do %>
-  <%= render "shared/notification_badge" %>
-<% end %>
-
-<%= turbo_stream.prepend "notifications", partial: "notifications/notification", locals: { notification: @notification } %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,15 +1,15 @@
 <div class="p-1 md:p-4">
   <div class="flex flex-col p-1 items-center justify-center w-full max-w-2xl mx-auto bg-base-100 rounded-4xl">
-    <h1 class="text-center text-base md:text-xl p-2 md:p-4 border-b border-base-200 w-full">
+    <h1 class="text-center text-lg md:text-xl p-2 md:p-4 border-b border-base-200 w-full">
       <%= t('.title') %>
     </h1>
 
     <% if @notifications.present? %>
-    <div class="flex flex-col items-center max-w-2xl p-1 md:py-2 md:px-15">
+    <div class="flex flex-col items-center max-w-2xl p-1 md:py-2 md:px-10">
       <div class="flex flex-col w-full items-end p-1">
         <%= link_to "すべて既読",
             mark_all_as_read_notifications_path,
-            data: { turbo_method: :patch, turbo_frame: "_top" },
+            data: { turbo_method: :patch },
             class: "btn btn-sm btn-outline btn-secondary" %>
       </div>
       <div id="notifications-list">

--- a/app/views/notifications/mark_all_as_read.turbo_stream.erb
+++ b/app/views/notifications/mark_all_as_read.turbo_stream.erb
@@ -1,7 +1,0 @@
-<%= turbo_stream.replace "notifications-list" do %>
-  <%= render @notifications %>
-<% end %>
-
-<%= turbo_stream.replace "notification-badge" do %>
-  <%= render "shared/notification_badge" %>
-<% end %>

--- a/app/views/notifications/update_all.turbo_stream.erb
+++ b/app/views/notifications/update_all.turbo_stream.erb
@@ -1,7 +1,0 @@
-<%= turbo_stream.replace dom_id(@notification) do %>
-  <%= render @notification %>
-<% end %>
-
-<%= turbo_stream.replace "notification-badge" do %>
-  <%= render "shared/notification_badge" %>
-<% end %>

--- a/app/views/shared/_notification_badge.html.erb
+++ b/app/views/shared/_notification_badge.html.erb
@@ -1,5 +1,5 @@
-<div id="notification-badge" class="absolute top-0 sm:top-1 right-3 sm:right-10">
-  <% if @unchecked_notifications_count.to_i > 0 %>
+<% if @unchecked_notifications_count.to_i > 0 %>
+  <div class="absolute top-0 sm:top-1 right-4 sm:right-10">
     <div class="status status-accent animate-bounce"></div>
-  <% end %>
-</div>
+  </div>
+<% end %>


### PR DESCRIPTION
## 概要
通知既読後のUI表示が更新されないバグを修正しました。
通知一覧から投稿詳細へ遷移した時にフッターの未読バッジが消え、通知一覧へ戻った時も通知文のフォントカラーが既読の色になり、未読バッジも表示されなくなりました。

### 🔧 修正内容
- `NotificationsController`  
  - `update`・`mark_all_as_read` をリダイレクト方式に変更  
  - 不要になった `format.turbo_stream` 部分削除
- `_notification.html.erb`  
  - 通知全体を投稿詳細へのリンクに変更  
  - `data: { turbo_method: :patch }` は残す  
- `index.html.erb`  
  - 全て既読ボタンの動作調整  
- `_notification_badge.html.erb`  
- 不要になった以下Turbo Streamテンプレートを削除  
  - `create.turbo_stream.erb`  
  - `update.turbo_stream.erb`  
  - `mark_all_as_read.turbo_stream.erb`  
- ユーザー詳細への遷移はなくし、投稿詳細への画面遷移のみに変更

###  ？なぜ発生したか
- 投稿詳細やユーザー詳細画面から戻るボタンで通知画面に戻った場合、Turbo Drive のキャッシュにより、既読状態がUIに反映されず未読表示が残っていた  
- Turbo Streamを使った更新では、リスト全体の書き換えやバッジ更新が期待通り反映されなかった  

### 📝 どの様に対応したか
- 既読処理を通知一覧画面でまとめて行うように変更  
- リダイレクト方式に切り替え、常に最新の通知状態をレンダリング  
- 不要なTurbo Stream用テンプレートを削除  
- 通知パーシャルを全体リンクに変更し、UIと挙動を統一  

### 🎨 UI/UX関連
- モバイル時のタイトルのフォントを拡大
- モバイル時のバッジの位置を調整
- 未読時のフォントカラーを微調整

### ✅ 確認項目
- [ ] 通知一覧から投稿詳細へのリンクで既読になること  
- [ ] 全て既読ボタン押下でバッジが消えること  
- [ ] 投稿詳細・ユーザー詳細から戻るボタンで通知一覧が正しく表示されること  
- [ ] Turbo Stream テンプレートを削除しても他の通知機能に影響がないこと  
- [ ] 他ユーザーが通知URLを直打ちした場合、アクセスできずリダイレクトされること  

close #198
