### PR TITLE
fix: notification_id関連の不要なコードを削除

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -59,14 +59,6 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id]).decorate
     @comment = Comment.new
     @comments = @post.comments.includes(:user).order(created_at: :desc)
-
-    # 他ユーザーが通知URLの直打ちで通知対象を閲覧できないように
-    if params[:notification_id].present?
-      notification = Notification.find(params[:notification_id])
-      if notification.recipient_id != current_user.id
-        redirect_to notifications_path, alert: "無効なURLです" and return
-      end
-    end
   end
 
   def destroy


### PR DESCRIPTION
## 概要
バグ修正時に追加したnotification_id関連のコードが不要であることが判明したため、削除しました。


### 🔧 修正内容
- notification_id関連のコードを削除

### ✅ 確認項目
- [ ] 通知一覧から投稿詳細への画面遷移が問題なく行えること

close #200 