### PR TITLE
Fix/#204 notification mobile redirect

### DIFF
--- a/app/javascript/controllers/from_post_controller.js
+++ b/app/javascript/controllers/from_post_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+// モバイル時のブラウザバック問題を回避するためのクエリパラメータ追加
+export default class extends Controller {
+  connect() {
+    const url = new URL(this.element.href, window.location.origin) // URLオブジェクトを作成
+    if (window.innerWidth < 640) {
+      url.searchParams.set("from_post", "true") // キャッシュ問題回避のため
+      this.element.href = url.toString() // URLオブジェクトを文字列に変換
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -5,6 +5,8 @@
 import { application } from "./application"
 import FadeController from "./fade_controller"
 import ResetFormController from "./reset_form_controller"
+import FromPostController from "./from_post_controller"
 
 application.register("fade", FadeController)
 application.register("reset-form", ResetFormController)
+application.register("from-post", FromPostController)

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,5 +1,5 @@
 <%= link_to notification_path(notification),
-            data: { turbo_method: :patch },
+            data: { turbo_method: :patch, controller: "from-post" },
             class: "block w-full border-b border-base-200 px-1 sm:px-4 py-3 hover:opacity-80" do %>
   <div class="flex flex-row items-start gap-2 mb-1">
     <!-- アイコン -->

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -12,9 +12,7 @@
             data: { turbo_method: :patch },
             class: "btn btn-sm btn-outline btn-secondary" %>
       </div>
-      <div id="notifications-list">
         <%= render @notifications %>
-      </div>
       </div>
       <div class="m-4">
         <%== pagy_nav(@pagy) %>


### PR DESCRIPTION
## 概要
モバイル時に通知一覧から投稿詳細へ遷移後、ブラウザの戻るボタンで通知一覧に戻る挙動を安定させるための対応を行いました。

### 🔧 修正内容
- JavaScriptでデバイスを判定し、モバイル時のみ特別なURL（`from_post=true`）へ遷移するよう変更

### 📝 なぜ発生したか
- モバイルブラウザのキャッシュ問題により、モバイル表示時に通知一覧→投稿詳細→戻る のルートが正しく通知一覧に戻らず、元のページに戻る挙動になっていた

### 💬 どの様に対応したか
- Stimulusを利用して、モバイル時のみURLに `from_post=true` を付与(クエリパラメータでキャッシュ回避)
- PC表示時は従来通りのURLで遷移させ、URLにパラメータが不要になるよう調整(Stimulusで条件分岐付きURL変更)

### その他修正
- `app/views/notifications/index.html.erb`の不要なnotifications-listのdivを削除

### ✅ 確認項目
- [ ] モバイルで通知一覧から投稿詳細に遷移した後、ブラウザの戻るボタンで通知一覧に戻ること
- [ ] PC表示ではURLに `from_post` パラメータが付与されず、通常遷移で問題ないこと
- [ ] 通知文・リンクのクリックで投稿詳細に正しく遷移すること


close #204
