### PR TITLE
fix: 商品一覧の不要なtooltipを削除&文言調整

### DIFF
--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -10,17 +10,6 @@ module CategoriesHelper
     end
   end
 
-  def new_post_link_or_tooltip(product, options = {}, &block)
-    if user_signed_in?
-      link_to new_post_path(product_id: product.id), options, &block
-    else
-      content_tag :div, options.merge(
-        class: "#{options[:class]} tooltip tooltip-top",
-        data: { tip: t("defaults.require_login") }
-      ), &block
-    end
-  end
-
   def new_product_link_or_tooltip(options = {}, &block)
     if user_signed_in?
       link_to new_post_path, options, &block

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -3,10 +3,9 @@
     <h1 class="text-center text-base md:text-xl p-4 border-b border-base-200 w-full">
       <%= t('.title') %></h1>
 
-    <% if user_signed_in? %>
-    <% else %>
+    <% unless user_signed_in? %>
       <div class="text-xs sm:text-sm text-stone-400 py-4">
-        <%= t('defaults.require_login_user_rating') %>
+        ※ <%= t('defaults.require_login_user_rating') %>
       </div>
     <% end %>
 

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -52,15 +52,17 @@
                       </p>
                     </div>
                     <!-- 投稿画面へ遷移 -->
+                   <% if user_signed_in? %>
                     <div class="mt-4 md:mt-6 text-center">
-                      <%= new_post_link_or_tooltip(product,
-                          class: "bg-success rounded-full px-3 py-1 md:px-4 py-3
-                          inline-flex items-center shadow-sm transition hover-animation") do %>
-                          <span class="text-xs md:text-sm">
-                            <%= t('defaults.buttons.new_post') %>
-                          </span>
+                      <%= link_to new_post_path(product_id: product.id),
+                                  class: "bg-success rounded-full px-3 py-1 md:px-4 py-3
+                                          inline-flex items-center shadow-sm transition hover-animation" do %>
+                        <span class="text-xs md:text-sm">
+                          <%= t('defaults.buttons.new_post') %>
+                        </span>
                       <% end %>
                     </div>
+                   <% end %>
                   </div>
                 <% end %>
               </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -3,7 +3,7 @@ ja:
     delete_confirm: 削除しますか？
     require_login: ログインが必要です
     require_login_user_profile: ユーザー詳細を見るにはログインが必要です
-    require_login_user_rating: ※ あまピタ評価をするにはログインが必要です
+    require_login_user_rating: あまピタ評価をするにはログインが必要です
     placeholders:
       search_word: キーワードを入力
       search_products: 商品名を入力


### PR DESCRIPTION
## 概要
前回のtooltip実装 #119 において、以下の問題を発見したため修正しました。
- 商品一覧で不要な箇所にtooltipが表示されている
- tooltip文言が一部不自然
---

### 🔧 修正内容
- 未使用のnew_post_link_or_tooltipヘルパーメソッドを削除
- categories/indexの条件分岐をunlessで簡潔化
- categories/showで直接的な条件分岐に変更
- i18nファイルから装飾記号を削除し、ビューで制御


### ✅ 確認事項
- [x] 未ログイン時に適切なメッセージが表示される(カテゴリ一覧)
- [x] ログイン時にメッセージが非表示になる(カテゴリ一覧)
- [x] 投稿ボタンがログイン時のみ表示される(商品一覧)
- [x] レスポンシブ表示が正常に動作する

close #212 