### PR TITLE
Fix/#214 pagination bug

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -5,7 +5,7 @@ class NotificationsController < ApplicationController
     @notifications = current_user.received_notifications
                                  .includes(:sender, :notifiable)
                                  .order(created_at: :desc)
-    @pagy, @notifications = pagy(@notifications, limit: 15)
+    @pagy, @notifications = pagy(@notifications, limit: 12)
   end
 
   def update

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,7 @@ class PostsController < ApplicationController
 
     @q_recommend, recommended_scope = fetch_recommended_posts
     @pagy_recommend, @recommended_posts = pagy(recommended_scope)
-    @recommended_posts = @recommended_posts
+    @recommended_posts = @recommended_posts.decorate
   end
 
 
@@ -80,7 +80,6 @@ class PostsController < ApplicationController
                                     .where(sweetness_rating: :perfect_sweetness)
                                     .includes(:user, :category)
                                     .order(created_at: :desc)
-                                    .decorate
     [ q_recommend, recommended_posts ]
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,13 +1,16 @@
 class ProductsController < ApplicationController
   def show
     @product = Product.find(params[:id]).decorate
-    @posts = @product.decorate.posts.order(created_at: :desc)
+
+    posts_query = @product.posts.includes(:user).order(created_at: :desc)
+
+    @posts = @product.decorate.posts.includes(:user).order(created_at: :desc)
     @average_scores = @product.average_sweetness_scores
     @user_post = @posts.find_by(user_id: current_user.id) if user_signed_in?
 
     @product_image_uploader = @product.posts.includes(:user).order(:created_at).first
     @product_image_uploader_id = @product_image_uploader&.user_id
-
-    @pagy_bookmarks, @products = pagy(Product.order(id: :desc))
+    # レビュー一覧
+    @pagy, @posts = pagy(@posts, limit: 5)
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -16,13 +16,19 @@ class ProfilesController < ApplicationController
 
   def show
     @user = @user.decorate
-    @sweetness_type =  @user.sweetness_type
     @sweetness_profiles = @user.sweetness_profiles.last
-    @posts = @user.posts.all.order(created_at: :desc).decorate
-    @bookmarks = @user.bookmark_products
-    @products = @user.bookmark_products.decorate
-    @pagy_posts, @posts = pagy(@user.posts.order(id: :desc))
-    @pagy_bookmarks, @bookmarks = pagy(@user.bookmarks.order(id: :desc))
+    @sweetness_type =  @user.sweetness_type
+
+    # デフォルトは投稿タブ
+    @active_tab = params[:tab].presence_in([ "posts", "bookmarks" ]) || "posts"
+    # 投稿
+    posts_query = @user.posts.order(id: :desc)
+    @pagy_posts, @posts = pagy(posts_query, limit: 10, page_param: :posts_page)
+    @posts = @posts&.decorate
+    # ブックマーク
+    bookmarks_query = @user.bookmark_products.order(id: :desc)
+    @pagy_bookmarks, @bookmarks = pagy(bookmarks_query, limit: 10, page_param: :bookmarks_page)
+    @bookmarks = @bookmarks&.decorate
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,12 +1,12 @@
 class UsersController < ApplicationController
   def show
     @user = User.find(params[:id]).decorate
-    @posts = @user.posts.order(created_at: :desc).decorate
-    @sweetness_type = @user.sweetness_type
     @sweetness_profiles = @user.sweetness_profiles.last
+    @sweetness_type = @user.sweetness_type
 
-    @bookmarks = @user.bookmark_products.decorate
-    @pagy_posts, @posts = pagy(@user.posts.order(id: :desc))
-    @pagy_bookmarks, @products = pagy(@user.bookmarks.includes(:product).order(id: :desc))
+    # 投稿一覧
+    posts_query = @user.posts.order(id: :desc)
+    @pagy_posts, @posts = pagy(posts_query, limit: 10)
+    @posts = @posts&.decorate
   end
 end

--- a/app/views/products/_user_bookmarks.html.erb
+++ b/app/views/products/_user_bookmarks.html.erb
@@ -1,11 +1,11 @@
 <div class="w-full p-3">
-  <% @bookmarks.each do |bookmark| %>
+  <% @bookmarks.each do |product| %>
     <!-- カード -->
     <div class="card bg-base-100 p-2 shadow-sm min-h-52 rounded-4xl flex flex-col md:flex-row relative mb-4">
       
       <!-- 画像 -->
       <figure class="flex-shrink-0 w-full md:w-52">
-        <% product = bookmark.product.decorate %>
+        <% product = product.decorate %>
         <%= product.product_image(class: "w-30 h-30 md:w-40 md:h-40") %>
       </figure>
       

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -189,7 +189,7 @@
           </div>
         <% end %>
         <div class="flex items-center justify-center p-4">
-          <%== pagy_nav(@pagy_bookmarks) %>
+          <%== pagy_nav(@pagy) %>
         </div>
       </div>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,8 +1,13 @@
-<%= render "shared/user_profile",
+<%= render "shared/user_basic_info",
     user: @user,
     sweetness_type: @sweetness_type,
     sweetness_profiles: @sweetness_profiles,
-    posts: @posts,
-    bookmarks: @bookmarks,
     chart_id: "radarChart",
     show_edit_button: true %>
+
+<%= render "shared/profile_tab", 
+    posts: @posts, 
+    pagy_posts: @pagy_posts,
+    bookmarks: @bookmarks,
+    pagy_bookmarks: @pagy_bookmarks,
+    active_tab: @active_tab %>

--- a/app/views/shared/_profile_tab.html.erb
+++ b/app/views/shared/_profile_tab.html.erb
@@ -1,0 +1,48 @@
+    <div class="p-6">
+      <div class="tabs tabs-border justify-center w-full">
+        <!-- 投稿 -->
+        <a href="<%= profile_path(tab: 'posts') %>" 
+            class="tab text-sm md:text-base text-secondary hover:text-secondary <%= 'tab-active' if active_tab == 'posts' %>">
+            <%= t('profiles.tabs.posts') %>
+        </a>
+
+        <!-- ブックマーク -->
+        <a href="<%= profile_path(tab: 'bookmarks') %>" 
+            class="tab text-sm md:text-base text-accent hover:text-accent <%= 'tab-active' if active_tab == 'bookmarks' %>">
+            <%= t('profiles.tabs.bookmarks') %>
+        </a>
+        </div>
+
+        <!-- タブコンテンツ -->
+        <div class="w-full">
+        <% if active_tab == 'posts' %>
+        <div class="border-3 border-secondary bg-white rounded-4xl w-full md:p-6">
+            <div class="flex flex-col mx-auto items-center justify-center text-sm text-base-300 sm:text-base w-full">
+                <% if posts.present? %>
+                <%= render posts %>
+                <div class="flex items-center justify-center p-4">
+                    <%== pagy_nav(pagy_posts, link_extra: 'data-turbo-action="replace"', params: { tab: 'posts' }) %>
+                </div>
+                <% else %>
+                <p class="p-4"><%= t('profiles.empty_states.no_posts') %></p>
+                <% end %>
+            </div>
+        </div>
+        <% elsif active_tab == 'bookmarks' %>
+        <div class="border-3 border-accent bg-white rounded-4xl w-full md:p-6">
+            <div class="flex flex-col mx-auto items-center justify-center text-sm text-base-300 sm:text-base w-full">
+                <% if bookmarks.present? %>
+                <%= render "products/user_bookmarks", products: bookmarks %>
+                <div class="flex items-center justify-center p-4">
+                    <%== pagy_nav(pagy_bookmarks, link_extra: 'data-turbo-action="replace"', params: { tab: 'bookmarks' }) %>
+                </div>
+                <% else %>
+                <p class="p-4"><%= t('profiles.empty_states.no_bookmarks') %></p>
+                <% end %>
+            </div>
+        </div>
+        <% end %>
+        </div>
+      </div>
+  </div>
+</div>

--- a/app/views/shared/_user_basic_info.html.erb
+++ b/app/views/shared/_user_basic_info.html.erb
@@ -49,7 +49,7 @@
 
     <!-- チャート -->
     <% if sweetness_profiles.present? %>
-      <div class="flex justify-center md:p-2 w-full">
+      <div class="flex justify-center pb-4 w-full">
         <div class="w-full max-w-md md:max-w-lg p-2 rounded-3xl bg-white">
 
           <div class="flex justify-end text-sm md:text-base font-bold mb-2">
@@ -96,42 +96,3 @@
         </div>
       <% end %>
     <% end %>
-
-    <!-- タブ -->
-    <div class="tabs tabs-border py-2 md:py-6 justify-center w-full">
-      <!-- 投稿 -->
-      <input type="radio" name="my_tabs_4" role="tab"
-        class="tab text-xs md:text-base text-primary hover:text-primary"
-        aria-label="<%= t('profiles.tabs.posts') %>" checked />
-      <div role="tabpanel" class="tab-content md:p-6 border-primary bg-white rounded-4xl w-full">
-        <div class="flex flex-col mx-auto items-center justify-center text-xs md:text-sm w-full">
-          <% if @posts.present? %>
-            <%= render @posts %>
-              <div class="flex items-center justify-center p-4">
-                <%== pagy_nav(@pagy_posts) %>
-              </div>
-          <% else %>
-            <p class="p-4"><%= t('profiles.empty_states.no_posts') %></p>
-          <% end %>
-        </div>
-      </div>
-
-      <!-- ブックマーク -->
-      <input type="radio" name="my_tabs_4" role="tab"
-        class="tab text-xs md:text-base text-accent hover:text-accent"
-        aria-label="<%= t('profiles.tabs.bookmarks') %>" />
-      <div role="tabpanel" class="tab-content md:p-6 border-accent bg-white rounded-4xl w-full">
-        <div class="flex flex-col mx-auto items-center justify-center text-xs md:text-sm w-full">
-          <% if @bookmarks.present? %>
-            <%= render "products/user_bookmarks", products: @products %>
-              <div class="flex items-center justify-center p-4">
-              <%== pagy_nav(@pagy_bookmarks) %>
-            </div>
-          <% else %>
-            <p class="p-4"><%= t('profiles.empty_states.no_bookmarks') %></p>
-          <% end %>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>

--- a/app/views/shared/_user_posts_tab.html.erb
+++ b/app/views/shared/_user_posts_tab.html.erb
@@ -1,0 +1,19 @@
+    <div class="tabs tabs-border py-2 md:py-6 justify-center w-full">
+      <input type="radio" name="my_tabs_4" role="tab"
+        class="tab text-sm md:text-base text-secondary hover:text-secondary"
+        aria-label="<%= t('profiles.tabs.posts') %>" checked />
+        <div role="tabpanel" class="tab-content md:p-6 border-secondary bg-white rounded-4xl w-full">
+        <div class="flex flex-col mx-auto items-center justify-center text-xs md:text-sm w-full">
+            <% if @posts.present? %>
+            <%= render @posts %>
+                <div class="flex items-center justify-center p-4">
+                <%== pagy_nav(@pagy_posts) %>
+                </div>
+            <% else %>
+            <p class="p-4"><%= t('profiles.empty_states.no_posts') %></p>
+            <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,8 +1,8 @@
-<%= render "shared/user_profile",
+<%= render "shared/user_basic_info",
     user: @user,
     sweetness_type: @sweetness_type,
     sweetness_profiles: @sweetness_profiles,
-    bookmarks: @bookmarks,
-    posts: @posts,
     chart_id: "radarChart",
     show_edit_button: false %>
+
+<%= render "shared/user_posts_tab", posts: @posts, pagy: @pagy_posts %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -10,7 +10,7 @@
 # You can set any pagy variable as a Pagy::DEFAULT. They can also be overridden per instance by just passing them to
 # Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
 # Here are the few that make more sense as DEFAULTs:
-Pagy::DEFAULT[:limit]       = 20                  # default
+Pagy::DEFAULT[:limit]       = 16                # default
 # Pagy::DEFAULT[:size]        = 7                     # default
 # Pagy::DEFAULT[:ends]        = true                  # default
 # Pagy::DEFAULT[:page_param]  = :page                 # default
@@ -151,8 +151,8 @@ Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
 
 # Overflow extra: Allow for easy handling of overflowing pages
 # See https://ddnexus.github.io/pagy/docs/extras/overflow
-# require 'pagy/extras/overflow'
-# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+require "pagy/extras/overflow"
+Pagy::DEFAULT[:overflow] = :last_page    # default  (other options: :last_page and :exception)
 
 # Trim extra: Remove the page=1 param from links
 # See https://ddnexus.github.io/pagy/docs/extras/trim


### PR DESCRIPTION
## 概要

投稿・商品一覧・マイページでのPagy::OverflowErrorを修正し、ユーザーページとマイページの機能分離を行いました。

---

### 🎯 解決した課題
- Pagy::OverflowErrorによるアプリケーションクラッシュ
- ユーザーページでブックマークが見える問題（プライバシー問題）
- マイページのページネーションがタブ切り替えで正常に動作しない問題

### 🔧 修正内容
- pagy.rbでoverflow機能を有効化してPagy::OverflowErrorを解決
- 各コントローラーで適切なページネーション設定を追加
- 画面ごとの表示数を調整"

### 📋 その他修正
- 共通パーシャルを機能別に分割
  - `_user_basic_info.html.erb`: ユーザー基本情報（共通）
  - `_user_posts_tab.html.erb`: 投稿一覧（公開用）
  - `_profile_tab.html.erb`: 投稿＋ブックマーク（プライベート用）
- ユーザーページからブックマークタブを削除してプライバシー保護
- マイページのタブ切り替え問題を修正

### ✅ 確認事項
#### ページネーション機能
- [ ] 各画面でページネーションが正しく動作する
- [ ] 存在しないページ番号へのアクセス時にエラーが発生しない
- [ ] 最後のページ以降へのアクセス時に適切にハンドリングされる

#### ユーザーページ（users/show）
- [ ] 投稿のみ表示される
- [ ] ブックマークタブが表示されない
- [ ] 他ユーザーのプライベート情報が見えない

#### マイページ（profiles/show）
- [ ] 投稿タブとブックマークタブが表示される
- [ ] タブ切り替えが正常に動作する

close #214