### PR TITLE
Fix/#189 post award modal

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -32,8 +32,7 @@ class PostsController < ApplicationController
       # バッジの付与
       new_badge = PostBadge.check_and_award_post_badges(current_user)
       # 新しいバッジであればモーダル表示
-      flash[:badge_awarded] = new_badge.name if new_badge
-
+      session[:badge_modal] = new_badge.name if new_badge&.name.present?
       redirect_to post_path(@post), notice: t("defaults.flash_message.created", item: Post.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_created", item: Post.model_name.human)
@@ -59,6 +58,11 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id]).decorate
     @comment = Comment.new
     @comments = @post.comments.includes(:user).order(created_at: :desc)
+
+    # モーダル表示用のフラグを保存してからsessionをクリア
+    @show_badge_modal = session[:badge_modal].present?
+    @badge_name = session[:badge_modal]
+    session.delete(:badge_modal)
   end
 
   def destroy

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -63,7 +63,6 @@
   <body class="min-h-screen flex flex-col bg-center bg-no-repeat bg-fixed bg-cover font-kiwi">
     <%= render 'shared/header' %>
     <main class="container flex-1 pt-20 pb-14 md:pb-20 px-4 mx-auto">
-      <%= turbo_frame_tag "modal" %>
       <%= render 'shared/flash_messages' %>
       <%= yield %>
     </main>

--- a/app/views/posts/_badge_modal.html.erb
+++ b/app/views/posts/_badge_modal.html.erb
@@ -1,15 +1,16 @@
-<input type="checkbox" id="badge-modal" class="modal-toggle" checked>
-<div class="modal">
-  <div class="modal-box relative bg-success justify-center">
-    <p class="text-base mb-4 text-center">
+<input type="checkbox" id="badge-modal" class="modal-toggle" checked />
+<div class="modal" role="dialog">
+  <div class="modal-box bg-success">
+    <p class="text-sm sm:text-base mb-4 text-center">
       <%= t('defaults.badge_modal.title') %>
     </p>
-    <h3 class="text-center text-xl font-semibold mb-6">
-      <%= t('defaults.badge_modal.message', badge_name: flash[:badge_awarded]) %>
+    <h3 class="flex flex-row justify-center text-center text-lg sm:text-xl font-semibold mb-6 gap-1">
+      <%= image_tag "badge.svg", class: "h-7 w-7 sm:h-8 sm:w-8" %>
+      <%= t('defaults.badge_modal.message', badge_name: badge_name) %>
     </h3>
     <div class="flex flex-col justify-center items-center gap-2">
       <%= image_tag "smiley-wink.svg", class: "h-8 w-8" %>
-      <p class="text-xs md:text-sm mb-6 text-center">
+      <p class="text-sm mb-6 text-center">
         <%= t('defaults.badge_modal.thanks_message') %>
       </p>
     </div>
@@ -19,4 +20,5 @@
       </label>
     </div>
   </div>
+  <label class="modal-backdrop" for="badge-modal"></label>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,5 @@
-<%= turbo_frame_tag "modal" do %>
-  <% if flash[:badge_awarded] %>
-    <%= render "badge_modal" %>
-  <% end %>
+<% if @show_badge_modal %>
+  <%= render "badge_modal", badge_name: @badge_name %>
 <% end %>
 
 <div class="p-2 md:p-4">

--- a/app/views/static_pages/_top_amapita_explanation.html.erb
+++ b/app/views/static_pages/_top_amapita_explanation.html.erb
@@ -52,8 +52,8 @@
   <div class="flex flex-col items-start py-4 md:p-4">
     <% badges = [
       {count: '1件以上', name: 'スイーツマスターLv.1'},
-      {count: '10件以上', name: '甘の冒険者'},
-      {count: '20件以上', name: '甘界の番長'}
+      {count: '5件以上', name: '甘の冒険者'},
+      {count: '10件以上', name: '甘界の番長'}
     ] %>
 
     <% badges.each do |b| %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -36,9 +36,9 @@ ja:
       sweetness_average: みんなの評価
       sweetness_other_user: ユーザーの評価
     badge_modal:
-      title: あなたの称号が変わりました。
-      message: "『%{badge_name}』"
-      thanks_message: たくさんの甘さ評価ありがとうございます！
+      title: あなたの称号が変わりました ✧*
+      message: "%{badge_name}"
+      thanks_message: ✧* たくさんの甘さ評価ありがとうございます！✧*
     message:
       no_post: 投稿がありません
   errors:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -88,15 +88,17 @@ end
 badges = [
   { name: "甘さツイン", badge_kind: 1, threshold: nil },
   { name: "スイーツマスターLv.1", badge_kind: 0, threshold: 1 },
-  { name: "甘の冒険者", badge_kind: 0, threshold: 10 },
-  { name: "甘界の番長", badge_kind: 0, threshold: 20 },
-  { name: "甘の大天使", badge_kind: 0, threshold: 30 },
-  { name: "甘界の覇者", badge_kind: 0, threshold: 40 },
+  { name: "甘の冒険者", badge_kind: 0, threshold: 5 },
+  { name: "甘界の番長", badge_kind: 0, threshold: 10 },
+  { name: "甘の大天使", badge_kind: 0, threshold: 15 },
+  { name: "甘界の覇者", badge_kind: 0, threshold: 30 },
   { name: "伝説のあまピタ民", badge_kind: 0, threshold: 50 }
 ]
 
 badges.each do |b|
-  Badge.find_or_initialize_by(threshold: b[:threshold], badge_kind: b[:badge_kind]).update!(
-    name: b[:name]
+  badge = Badge.find_or_initialize_by(name: b[:name])
+  badge.update!(
+    badge_kind: b[:badge_kind],
+    threshold: b[:threshold]
   )
 end


### PR DESCRIPTION
## 概要
投稿数に応じたモーダルが表示されない不具合を修正しました。

### 🔧 修正内容
- `ActionView::Template::Error (Missing partial shared/_badge_awarded …)` のエラー対応  
  - flashを使用していた箇所を`session`管理に変更  
  - モーダル表示用のフラグを`@show_badge_modal`として制御
- モーダルUIの調整（モーダル閉じる挙動を画面外クリック時にも適応）
- 投稿数バッジの付与カウントを変更  

### 🔧 技術的な変更点
- **データ管理**: `flash[:badge_awarded]` → `session[:badge_modal]`
- **表示制御**: `@show_badge_modal`フラグによる制御
- **セッション管理**: 表示後の自動削除処理を追加
- **UI改善**: `modal-backdrop`によるクリック外閉じ機能

### 💬 なぜ不具合が発生していたか
#179 の実装でフラッシュメッセージのデザインを変更した際、`app/views/layouts/application.html.erb`で<%= render 'shared/flash_messages' %>を呼ぶ様に変えたため、全てのフラッシュメッセージはshared配下でのみ呼ばれる様になっていた。
-> `flash[:badge_modal]`で呼んだモーダルはpostsのモーダルパーシャルが呼ばれず、`ActionView::Template::Error (Missing partial shared/_badge_awarded …)`のエラーが起こっていた。

### 📝 解決方法
shared配下で呼ばれないようにsessionに書き換え。＆ フラッシュ・Turboの組み合わせで閉じるイベントが消失していたためフラッシュ・Turboを削除しsessionへ変更

### ✅ 確認事項
- [ ] 投稿作成時に設定した投稿数でモーダルが表示されること
- [ ] バッジが正しく付与・更新されること  
- [ ] モーダル表示後、ページリロードで再表示されないこと
- [ ] モーダル外クリックで正常に閉じること
- [ ] 複数投稿での段階的なバッジ付与が動作すること

close #189 