### PR TITLE
feat: 楽天API通信機能のエラーハンドリングを実装

### DIFF
--- a/app/services/rakuten_api_service.rb
+++ b/app/services/rakuten_api_service.rb
@@ -1,27 +1,62 @@
 class RakutenApiService
+  MAX_RETRIES = 3
+  RETRY_DELAY = 2
+  TIMEOUT = 10
+
   def search(keyword)
     return nil if keyword.blank?
 
-    Rails.logger.info "Rakuten API: Searching for '#{keyword}'"
+    retries = 0
 
-    items = RakutenWebService::Ichiba::Item.search(keyword: keyword)
+    begin
+      Rails.logger.info "🔍 Rakuten API: Searching for '#{keyword}' (attempt #{retries + 1})"
 
-    if items.blank?
-      Rails.logger.warn "Rakuten API: No items found for '#{keyword}'"
-      return nil
+      items = RakutenWebService::Ichiba::Item.search(
+        keyword: keyword,
+        timeout: TIMEOUT
+      )
+
+      if items.blank?
+        Rails.logger.warn "📭 Rakuten API: No items found for '#{keyword}'"
+        return nil
+      end
+
+      item = items.first
+
+      Rails.logger.info "🎉 Rakuten API: Found '#{item['itemName']}'"
+
+      parse_item(item)
+
+    rescue Timeout::Error, Net::OpenTimeout => e
+      retries += 1
+
+      if retries < MAX_RETRIES
+        Rails.logger.warn "⏰ Rakuten API Timeout (attempt #{retries}/#{MAX_RETRIES}): #{e.message}. Retrying in #{RETRY_DELAY} seconds..."
+        sleep(RETRY_DELAY)
+        retry
+      else
+        Rails.logger.error "💥 Rakuten API: Max retries (#{MAX_RETRIES}) reached. #{e.message}"
+        nil
+      end
+
+    rescue JSON::ParserError => e
+      Rails.logger.error "📄 Rakuten API JSON Parse Error: #{e.message}"
+      nil
+
+    rescue StandardError => e
+      Rails.logger.error "❌ Rakuten API Error: #{e.class} - #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      nil
     end
+  end
 
-    item = items.first
+  private
 
-    Rails.logger.info "Rakuten API: Found '#{item['itemName']}'"
-
+  def parse_item(item)
     {
-      "name" => item["itemName"],
-      "url" => item["itemUrl"],
-      "imageUrl" => item["mediumImageUrls"]
+      "name" => item["itemName"] || "",
+      "url" => item["itemUrl"] || "",
+      "imageUrl" => item["mediumImageUrls"] || ""
     }
-  rescue => e
-    Rails.logger.error "Rakuten API Error: #{e.message}"
-    nil
   end
 end


### PR DESCRIPTION
## 概要
楽天API通信時のエラーハンドリングを実装しました。

### 📋 実装内容
- Timeout::Error / Net::OpenTimeout: リトライ処理で対応
- JSON::ParserError: パースエラーの適切な処理
- StandardError: 予期しないエラーの安全な処理
- リトライ回数・MAXリトライ回数・タイムアウトの秒数を定義

### 修正内容
- 絵文字を追加しログを追いやすい形に変更

close #137 