### PR TITLE
fix: マイページでメールアドレス編集を無効化

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -56,12 +56,12 @@
             <%= f.text_field :name, class: "input input-bordered w-full bg-white" %>
           </div>
 
-          <% if @google_user %>
-            <div class="mb-3 md:mb-6">
-              <%= t('activerecord.attributes.user.email') %>
-              <div class="border-2 border-[var(--color-base-400)] rounded-2xl w-full bg-base-200 py-2 px-3 text-sm">
-                <%= @user.email %>
-              </div>
+          <div class="mb-3 md:mb-6">
+            <%= t('activerecord.attributes.user.email') %>
+            <div class="border-2 border-[var(--color-base-400)] rounded-2xl w-full bg-base-200 py-2 px-3 text-sm">
+              <%= @user.email %>
+            </div>
+            <% if @google_user %>
               <div class="mt-4">
                 <label class="form-label"><%=t('.authentication') %></label>
               </div>
@@ -76,13 +76,8 @@
                   </span>
                 </span>
               </div>
-            </div>
-          <% else %>
-            <div class="mb-3 md:mb-6 w-full">
-              <%= f.label :email, class: "form-label" %>
-              <%= f.email_field :email, class: "input input-bordered bg-white w-full" %>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
 
           <div class="mb-3 md:mb-6">
             <%= f.label :self_introduction, class: "form-label" %>


### PR DESCRIPTION
## 概要
セキュリティ向上のため、マイページでのメールアドレス直接編集を無効化

### 変更内容
- メールアドレスフィールドをreadonly属性に変更
- Strong Parametersからemailを除外

### 確認方法
- [x] マイページでメールアドレスが編集不可になっていること

close #238 