### PR TITLE
add: 商品一覧にオートコンプリート機能実装

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -14,6 +14,17 @@ class CategoriesController < ApplicationController
     @product_stats = product_stats(@products)
   end
 
+  def autocomplete
+    @category = Category.find_by!(slug: params[:slug])
+    @products = @category.products
+                         .where("name LIKE ? OR manufacturer LIKE ?", "%#{params[:q]}%", "%#{params[:q]}%")
+                         .limit(10)
+                         .select(:name, :manufacturer)
+    respond_to do |format|
+      format.html { render partial: "categories/search", locals: { products: @products } }
+    end
+  end
+
   private
 
   def product_stats(products)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,8 +7,10 @@ import FadeController from "./fade_controller"
 import ResetFormController from "./reset_form_controller"
 import FromPostController from "./from_post_controller"
 import RakutenSearchController from "./rakuten_search_controller"
+import { Autocomplete } from "stimulus-autocomplete"
 
 application.register("fade", FadeController)
 application.register("reset-form", ResetFormController)
 application.register("from-post", FromPostController)
 application.register("rakuten-search", RakutenSearchController)
+application.register("autocomplete", Autocomplete)

--- a/app/views/categories/_search.html.erb
+++ b/app/views/categories/_search.html.erb
@@ -1,0 +1,11 @@
+<% @products.each do |product| %>
+  <li class="w-full flex items-center py-2 px-3 text-sm text-neutral hover:bg-stone-200 cursor-pointer border-b border-stone-200 last:border-b-0"
+      role="option"
+      data-autocomplete-value="<%= "#{product.name}" %>"
+      data-autocomplete-label="<%= "#{product.manufacturer} #{product.name}" %>">
+    <span><%= product.name %></span>
+    <% if product.manufacturer.present? %>
+      <span class="ml-2 text-base-300 text-xs"><%= product.manufacturer %></span>
+    <% end %>
+  </li>
+<% end %>

--- a/app/views/categories/_search_form.html.erb
+++ b/app/views/categories/_search_form.html.erb
@@ -6,14 +6,28 @@
 
     <!-- 商品名検索 -->
     <div class="flex flex-row items-stretch md:items-center gap-1 sm:gap-2 w-full">
-      <!-- カテゴリ情報を保持 -->
-      <%= f.hidden_field :category_slug, value: params.dig(:q, :category_slug) || @category&.slug %>
 
-      <!-- 検索入力 -->
-      <%= f.search_field :name_or_manufacturer_cont, 
-        class: "flex-1 bg-white rounded-4xl ring-2 w-full md:w-100 ring-[var(--color-base-400)] text-sm md:text-base md:py-2 px-4",
-        placeholder: t('defaults.placeholders.search_products'),
-        data: { search_clear_target: "input" } %>
+      <div data-controller="autocomplete"
+           data-autocomplete-url-value="<%= autocomplete_category_path(@category&.slug) %>"
+           data-autocomplete-param-name="q[name_or_manufacturer_cont]"
+           role="combobox"
+           class="relative w-full">
+
+        <!-- カテゴリ情報を保持 -->
+        <%= f.hidden_field :category_slug, value: params.dig(:q, :category_slug) || @category&.slug %>
+
+        <!-- 検索入力 -->
+        <%= f.search_field :name_or_manufacturer_cont, 
+          class: "flex-1 bg-white rounded-4xl ring-2 w-full md:w-100 ring-[var(--color-base-400)] text-sm md:text-base md:py-2 px-4",
+          placeholder: t('defaults.placeholders.search_products'),
+          data: { search_clear_target: "input",
+                  autocomplete_target: 'input' },
+                  aria: { autocomplete: "list" },
+                  autocomplete: "off" %>
+
+        <ul class="list-group bg-white absolute top-full left-0 w-full md:text-sm z-10 shadow-lg rounded-md"
+            data-autocomplete-target="results"></ul>
+      </div>
 
       <!-- 検索ボタン -->
       <%= f.submit t('helpers.submit.search'), 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,9 @@ Rails.application.routes.draw do
   resources :bookmarks, only: %i[index create destroy]
 
   resources :categories, only: %i[index show], param: :slug do
+    member do
+      get :autocomplete
+    end
     resources :products, only: %i[show]
   end
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.16",
     "chart.js": "^4.5.0",
-    "daisyui": "^5.0.47"
+    "daisyui": "^5.0.47",
+    "stimulus-autocomplete": "^3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,3 +203,8 @@ esbuild@^0.25.8:
     "@esbuild/win32-arm64" "0.25.8"
     "@esbuild/win32-ia32" "0.25.8"
     "@esbuild/win32-x64" "0.25.8"
+
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==


### PR DESCRIPTION
## 概要
カテゴリページの商品一覧で、商品名・メーカー名を対象としたオートコンプリート検索機能を追加

### 変更内容
- カテゴリ毎に商品名・メーカー名でサジェスト表示
- Stimulus-autocomplete を使用し、候補クリックで input に反映
- routes.rb を member に変更してカテゴリ単位の検索に対応
- 部分テンプレート `_search.html.erb` 作成
- package.json / yarn.lock を更新

### 確認事項
- [x] カテゴリページの検索入力に文字を入れると候補が下に表示されること
- [x] 候補をクリックすると入力フィールドに反映されること
- [x] 検索ボタンを押さなくても候補が出ること
- [x] 他のカテゴリに移動しても候補が正しいカテゴリ内の商品に限定されること

close #227 