### PR TITLE
fix: 甘さツインバッジの片側付与バグを修正・ログイン時のツイン判定を削除

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -25,8 +25,6 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   def after_sign_in_path_for(resource)
-    SweetnessTwins::Updater.new(resource).update_twins
-    SweetnessTwins::Badge.new(resource).refresh_twin_badges
     stored_location_for(resource) || posts_path
   end
 

--- a/app/services/sweetness_twins/badge.rb
+++ b/app/services/sweetness_twins/badge.rb
@@ -33,13 +33,18 @@ module SweetnessTwins
     def update_twin_badges(latest_profile)
       badge = ::Badge.find_by(badge_kind: :sweetness_twin)
       return unless badge
-      # ツインユーザーを取得
+
       twin_users = SweetnessTwins::Matcher.find_twins_for(latest_profile)
-      # ユーザーと新しいツインユーザーの古いツインバッジを削除
+
+      # 既存のツイン関係とバッジを全削除してから再計算する
+      # （最新のsweetness_profileに基づいたツインを反映するため）
       UserBadge.where(user_id: [ @user.id ] + twin_users.map(&:id), badge: badge).delete_all
-      # 新しいツインユーザーにバッジを付与
+
+      # 自分に付与（まだ無ければ）
+      UserBadge.find_or_create_by!(user: @user, badge: badge)
+      # 相手にも付与（まだ無ければ）
       twin_users.each do |twin_user|
-        UserBadge.create!(user: twin_user, badge: badge)
+        UserBadge.find_or_create_by!(user: twin_user, badge: badge)
       end
     end
   end

--- a/app/services/sweetness_twins/updater.rb
+++ b/app/services/sweetness_twins/updater.rb
@@ -30,10 +30,12 @@ module SweetnessTwins
     end
 
     def create_new_twins(latest_profile)
-      # 新しいツインユーザーを取得
       twin_users = SweetnessTwins::Matcher.find_twins_for(latest_profile)
+
+      # ツイン関係を双方向に付与（自分→相手、相手→自分）
       twin_users.each do |twin|
         SweetnessTwin.create!(user: @user, twin_user: twin)
+        SweetnessTwin.create!(user: twin, twin_user: @user)
       end
     end
   end


### PR DESCRIPTION
## 概要
甘さツイン再計算時に、既存のツインバッジを削除したあとで自分や相手に再付与できていなかった問題を修正しました。  

---

### 📋 修正内容
- `SweetnessTwins::Badge#update_twin_badges` を修正
  - 自分に対しても `find_or_create_by!` でバッジを再付与
- `SweetnessTwins::Updater#create_new_twins` を修正
  - Twin 関係を双方向で作成（`user → twin_user`、`twin_user → user`）

---

### 🔧その他微修正
- コメントを修正し、処理の意図（双方向付与・重複防止）を明示
- `delete_all` 後の再付与で重複登録を防止するため `find_or_create_by!` を使用

---

### ✅ 確認事項
- [x] 自分側・相手側双方に甘さツインバッジが付与されること
- [x] 診断後に甘さツイン相手のバッジが正しく反映されること
- [x] 重複登録が発生しないこと
- [x] DB 上で甘さツイン関係が双方向で作成されていること

close #242 
