### PR TITLE
feat: パスワードリセット機能を実装

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -7,9 +7,17 @@ class Users::PasswordsController < Devise::PasswordsController
   # end
 
   # POST /resource/password
-  # def create
-  #   super
-  # end
+  def create
+    begin
+      self.resource = resource_class.send_reset_password_instructions(resource_params)
+    # SMTP障害・通信エラー対応
+    rescue StandardError => e
+      Rails.logger.error("Password reset failed: #{e.class} - #{e.message}")
+    end
+    # paranoidモードでは常に成功メッセージを表示
+    flash[:notice] = t("devise.passwords.send_paranoid_instructions")
+    redirect_to new_user_session_path
+  end
 
   # GET /resource/password/edit?reset_password_token=abcdef
   # def edit
@@ -21,14 +29,14 @@ class Users::PasswordsController < Devise::PasswordsController
   #   super
   # end
 
-  # protected
+  protected
 
   # def after_resetting_password_path_for(resource)
   #   super(resource)
   # end
 
   # The path used after sending reset password instructions
-  # def after_sending_reset_password_instructions_path_for(resource_name)
-  #   super(resource_name)
-  # end
+  def after_sending_reset_password_instructions_path_for(resource_name)
+    new_user_session_path
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User < ApplicationRecord
   has_one_attached :avatar
 
   validates :name, presence: true, length: { maximum: 20 }, uniqueness: true
+  validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP },
+            uniqueness: { case_sensitive: false }
   validates :uid, presence: true, uniqueness: { scope: :provider }
   validates :self_introduction, length: { maximum: 100 }
 

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,12 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.name %>様</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>あまピタッ！をご利用いただきありがとうございます。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p>パスワード再設定用のURLを送付いたします。以下のURLより、パスワードの変更をお願いいたします。</p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= link_to 'パスワードを変更する', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p></p>
+
+<p>※上記のリンクにアクセスして新しいパスワードを作成するまで、パスワードは変更されません。</p>
+<p>※このメールにお心当たりの無い場合は、このメールを破棄していただけますようお願いいたします。</p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,40 @@
-<h2>Change your password</h2>
+<main class="container flex-1 pt-4 pb-14 sm:p-4 mx-auto flex items-center justify-center">
+  <div class="w-full max-w-lg bg-base-100 rounded-3xl px-4 md:px-15 md:py-2">
+    <div class="mb-6 text-center">
+      <h2 class="text-xl md:text-2xl text-neutral font-bold pt-4"><%= t('.title') %></h2>
+    </div>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <div class="form-control mb-2 sm:mb-4 p-2">
+        <div class="pl-2 pb-1">
+          <%= t('.new_password') %>
+        </div>
+        <%= f.password_field :password,
+            autofocus: true,
+            autocomplete: "new-password",
+            class: "input input-bordered w-full h-10 md:h-12 rounded-full px-4 focus:outline-none" %>
+        <% if @minimum_password_length %>
+          <p class="text-sm pl-3 pt-1 text-base-300">半角英数字・<%= @minimum_password_length %>文字以上</p>
+        <% end %>
+      </div>
+
+      <div class="form-control mb-2 sm:mb-4 p-2">
+        <div class="pl-2 pb-1">
+          <%= t('.password_confirmation') %>
+        </div>
+        <%= f.password_field :password_confirmation,
+            autocomplete: "new-password",
+            placeholder: t('activerecord.attributes.user.password_confirmation'),
+            class: "input input-bordered w-full h-10 md:h-12 rounded-full px-4 focus:outline-none" %>
+      </div>
+
+      <div class="form-control flex justify-center py-4">
+        <%= f.submit t('.change_password'), class: "bg-accent button-primary" %>
+      </div>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</main>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,24 @@
-<h2>Forgot your password?</h2>
+<main class="container flex-1 py-6 px-1 sm:p-4 mx-auto flex items-center justify-center">
+  <div class="w-full max-w-lg bg-base-100 rounded-3xl px-4 sm:px-15 sm:py-6">
+    <div class="mb-6 text-center">
+      <h2 class="text-xl md:text-2xl text-neutral font-bold pt-4"><%= t('.title') %></h2>
+    </div>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <div class="field py-5">
+        <div class="pl-2 pb-1">
+          <%= f.label :email %>
+        </div>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: t('defaults.placeholders.sample_email'),
+         class: "input input-bordered w-full h-12 rounded-full px-4 py-2 focus:outline-none" %>
+      </div>
+
+      <div class="form-control flex justify-center pt-2 pb-6 sm:pb-8">
+        <%= f.submit t('.submit'), class: "bg-accent button-primary" %>
+      </div>
+    <% end %>
+
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,49 +1,59 @@
-<main class="container flex-1 pt-4 pb-14 md:pb-20 px-4 mx-auto flex items-center justify-center">
-  <div class="w-full max-w-md bg-base-100 rounded-3xl px-4 md:px-10 md:py-6">
+<main class="container flex-1 pt-4 pb-14 sm:p-4 mx-auto flex items-center justify-center">
+  <div class="w-full max-w-lg bg-base-100 rounded-3xl px-4 md:px-15 md:py-2">
     <div class="mb-6 text-center">
-      <h2 class="text-xl md:text-2xl text-neutral font-bold pt-4">ログイン</h2>
-    </div>
-
-    <div class="mt-4 pt-2 text-center">
-      <%= render "devise/shared/links" %>
-    </div>
-
-    <div class="flex items-center my-6">
-      <div class="flex-grow border-t border-base-200"></div>
-      <span class="mx-4 text-base-200 text-sm">または</span>
-      <div class="flex-grow border-t border-base-200"></div>
+      <h2 class="text-xl md:text-2xl text-neutral font-bold pt-4"><%= t('.title') %></h2>
     </div>
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-      <div class="form-control mb-4 p-2">
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス",
-         class: "input input-bordered w-full h-10 md:h-12 rounded-full px-4 py-2 focus:outline-none" %>
+      <div class="form-control mb-2 sm:mb-4 p-2">
+        <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            placeholder: t('activerecord.attributes.user.email'),
+            class: "input input-bordered w-full h-10 md:h-12 rounded-full px-4 py-2 focus:outline-none" %>
       </div>
 
-      <div class="form-control mb-4 p-2">
-        <%= f.password_field :password, autocomplete: "current-password",  placeholder: "パスワード",
-         class: "input input-bordered w-full h-10 md:h-12 rounded-full px-4 py-2 focus:outline-none" %>
+      <div class="form-control mb-2 sm:mb-4 p-2">
+        <%= f.password_field :password, autocomplete: "current-password",
+            placeholder: t('activerecord.attributes.user.password'),
+            class: "input input-bordered w-full h-10 md:h-12 rounded-full px-4 py-2 focus:outline-none" %>
       </div>
 
       <% if devise_mapping.rememberable? %>
-        <div class="form-control mb-4 p-2">
+        <div class="form-control pl-4">
           <label class="inline-flex items-center">
-            <%= f.check_box :remember_me, class: "checkbox checkbox-sm md:checkbox-md checkbox-secondary mr-2" %>
+            <%= f.check_box :remember_me, class: "checkbox checkbox-sm checkbox-secondary mr-2" %>
             <%= f.label :remember_me, class: "text-sm" %>
           </label>
         </div>
       <% end %>
 
-      <div class="form-control flex justify-center pb-4">
-        <%= f.submit "ログイン", class: "bg-accent button-primary" %>
+      <div class="form-control flex justify-center pt-4">
+        <%= f.submit t('.login'), class: "bg-accent button-primary" %>
       </div>
     <% end %>
-    <div class="flex justify-center p-4 text-neutral">
-      ユーザー登録の方は
-      <%= link_to new_user_registration_path, class: "underline-offset-4 hover:underline transition-all" do %>
-      こちら
-    <% end %>
+
+    <div class="flex flex-col items-center p-8 gap-2 sm:gap-3 text-sm">
+      <div class="flex justify-center text-neutral">
+        <%= link_to new_user_registration_path, class: "underline-offset-4 hover:underline transition-all" do %>
+          <%= t('.to_register_page') %>
+      <% end %>
+      </div>
+      <div class="flex justify-center text-neutral">
+        <%= link_to new_user_password_path, class: "underline-offset-4 hover:underline transition-all" do %>
+          <%= t('.password_forget') %>
+      <% end %>
+      </div>
     </div>
+
+    <div class="flex items-center">
+      <div class="flex-grow border-t border-base-200"></div>
+        <span class="mx-4 text-stone-400 text-sm"><%= t('.or') %></span>
+      <div class="flex-grow border-t border-base-200"></div>
+    </div>
+
+    <div class="pt-4 pb-12 text-center">
+      <%= render "devise/shared/links" %>
+    </div>
+
   </div>
 </main>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,6 +42,16 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: "localhost",
+    user_name: ENV["GMAIL_USERNAME"],
+    password: ENV["GMAIL_PASSWORD"],
+    authentication: "plain",
+    enable_starttls_auto: true
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,6 +82,17 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.default_url_options = { protocol: "https", host: "amapita.com" }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              "smtp.gmail.com",
+    port:                 587,
+    domain:               "amapita.com",
+    user_name:            ENV["GMAIL_USERNAME"],
+    password:             ENV["GMAIL_PASSWORD"],
+    authentication:       "plain",
+    enable_starttls_auto: true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = ENV["GMAIL_USERNAME"]
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -90,7 +90,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -86,7 +86,7 @@ ja:
         send_me_reset_password_instructions: パスワードの再設定方法を送信する
       no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
       send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
-      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      send_paranoid_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
       updated: パスワードが正しく変更されました。
       updated_not_active: パスワードが正しく変更されました。
     registrations:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -10,6 +10,7 @@ ja:
       new_comment: コメントを書く...
       require_word: 2文字以上の商品名を入力
       manufacturer: メーカーまたは店名を入力
+      sample_email: sample@example.com
     select:
       category: カテゴリを選択
     flash_message:
@@ -108,6 +109,23 @@ ja:
     shared:
       header:
         logout: ログアウト
+  devise:
+    sessions:
+      new:
+        title: ログイン
+        login: ログイン
+        to_register_page: ユーザー登録の方はこちら
+        password_forget: パスワードをお忘れの方はこちら
+        or: または
+    passwords:
+      new:
+        title: パスワードリセット
+        submit: パスワード再設定用リンクを送信
+      edit:
+        title: パスワードの再設定
+        new_password: 新しいパスワード
+        password_confirmation: 新しいパスワード(確認用)
+        change_password: パスワード変更
   profiles:
     info: ユーザー情報
     total_post: "公開した甘さ評価：%{count} 件"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: "users/registrations",
     sessions: "users/sessions",
-    omniauth_callbacks: "users/omniauth_callbacks"
+    omniauth_callbacks: "users/omniauth_callbacks",
+    passwords: "users/passwords"
     }
 
   root "static_pages#top"


### PR DESCRIPTION
## 概要
Deviseのパスワードリセット機能を実装し、paranoidモードでの安全な挙動とメール送信設定を追加しました。  
ユーザーが登録済み／未登録のメールアドレスを入力しても同一メッセージを返す仕様とし、情報漏えいを防止しています。

---

### 📋 修正内容
- ルーティングの追加
- `Users::PasswordsController`へ下記を追記
  - `create` メソッドをオーバーライドし、paranoidモードで常に同一メッセージを返すよう実装  
  - SMTP送信失敗時のログ出力を追加  
- `devise.rb` にpranoidモードを追加  
- メール送信設定（development / production）をSMTP対応に変更  
- パスワードリセットメールテンプレートを作成
- パスワードリセット画面のUI調整  
- `User` モデルにemailカラムのバリデーションを追加 

✅ 確認事項
 - [x] パスワードリセットメールが正常に送信されること
 - [x] 更新したパスワードでログインできること
 - [x] 未登録メールアドレスでも同一のフラッシュメッセージが表示されること
 - [x] メール文面・リンクが正しく動作すること
 
close #52