### PR TITLE
fix: モバイル時のturboキャッシュによる無限ローディングバグを修正

### DIFF
--- a/app/views/shared/_user_basic_info.html.erb
+++ b/app/views/shared/_user_basic_info.html.erb
@@ -6,8 +6,19 @@
 
     <!-- ユーザー情報 -->
     <div class="flex flex-col justify-center items-center sm:flex-row sm:items-start sm:gap-6 w-full py-4">
-      <figure class="p-3" x-data="{ imageLoaded: false }"
-              x-init="imageLoaded = $el.querySelector('img')?.complete || false">
+      <!-- img.naturalHeightで実際の画像の高さがあるかチェック -->
+      <figure class="p-3"
+              x-data="{
+                imageLoaded: false,
+                check() {
+                  const img = $el.querySelector('img');
+                  this.imageLoaded = img?.complete && img?.naturalHeight !== 0;
+                }
+              }"
+              x-init="check()"
+              :key="user.id"
+              @turbo:load.window="check()"
+              @turbo:render.window="check()">
         <div x-cloak x-show="!imageLoaded" class="flex animate-pulse space-x-4">
           <div class="size-15 sm:size-20 rounded-full bg-base-200"></div>
         </div>
@@ -17,7 +28,7 @@
                 class: "size-15 sm:size-20",
                 loading: "lazy",
                 "@load" => "imageLoaded = true",
-                "@error"=> "imageLoaded = true"
+                "@error" => "imageLoaded = true"
               ) %>
         </div>
       </figure>


### PR DESCRIPTION
## 概要
モバイル端末でのTurbo遷移時に、ユーザーアバター画像が無限ローディング状態になるバグを修正しました。

### **問題**
- モバイルデバイスでページ遷移時にアバター画像のローディングアニメーションが終了しない
- Turboキャッシュにより`img.complete`が正しく動作しない場合がある
- 画像の読み込み状態判定が不正確

---

### 🔧 修正内容
- `img.complete` だけでなく、`img.naturalHeight !== 0` も確認することで、画像が正しく読み込まれたかをより正確に判定
- `x-data` に `check()` 関数を追加し、画像の読み込み状態を都度確認可能に
- Turboによる部分リロード時に再チェックされるよう、以下のイベントを追加  
  - `@turbo:load.window="check()"`
  - `@turbo:render.window="check()"`
- `:key="user.id"` を付与してユーザーごとのDOM再レンダリングを安定化
- `@error` の記法を整形（スペースの統一）

---

### ✅ 確認事項
- [ ] モバイル端末でのページ遷移時にアバター画像が正常に表示される
- [ ] デスクトップでの既存機能に影響がない
- [ ] ローディングアニメーションが適切なタイミングで終了する
- [ ] Turbo遷移時のキャッシュ状態が正しく処理される

close #246 
