### PR TITLE
improve: 投稿シェアOGP画像の表示改善

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,7 +40,7 @@ module ApplicationHelper
     return asset_url("ogp.png") unless post&.product&.name
 
     begin
-      product_text = CGI.escape("「#{post.product.name}」の")
+      product_text = URI.encode_www_form_component("「#{post.product.name}」の").gsub("+", "%20")
       text_color = "6a6565"
 
       image_configs = {
@@ -56,7 +56,7 @@ module ApplicationHelper
 
       "https://res.cloudinary.com/dbar0jd0k/image/upload/" \
       "l_text:TakaoGothic_50_bold:#{product_text}," \
-      "co_rgb:#{text_color},w_500,c_fit,g_north,y_60/" \
+      "co_rgb:#{text_color},c_fit,g_north,y_60/" \
       "#{image_path}"
     rescue => e
       Rails.logger.error "OGP画像生成エラー: #{e.message}"
@@ -65,8 +65,8 @@ module ApplicationHelper
   end
 
   def post_meta_tags(post)
-    ogp_image = generate_sweetness_ogp_url(post)  # ← ここで商品名＆甘さ評価に応じた画像を生成
-    title = "「#{post.product.name}」の甘さ評価"
+    ogp_image = generate_sweetness_ogp_url(post)
+    title = "甘さ評価"
     description = "甘すぎない、物足りなくない。あなたにぴったりの甘さが見つかるアプリ。"
 
     {
@@ -75,7 +75,7 @@ module ApplicationHelper
       og: {
         title: title,
         description: description,
-        image: ogp_image,  # ← 動的に生成されたCloudinary URLが入る
+        image: ogp_image,
         url: request.original_url,
         type: "article"
       },

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,7 +2,7 @@ class Product < ApplicationRecord
   include ImageValidatable
   has_one_attached :image
 
-  validates :name, presence: true, length: { maximum: 40 }
+  validates :name, presence: true, length: { maximum: 24 }
   validates :manufacturer, presence: true
   validates :name, uniqueness: { scope: :manufacturer, message: :name_manufacturer_taken }
   validates :category_id, presence: { message: :select }

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -123,9 +123,9 @@
               <%= image_tag rating_images[@post.sweetness_rating], class: "h-8 w-8" %>
               <p><%= I18n.t("enums.post.sweetness_rating.#{@post.sweetness_rating}") %></p>
             </div>
-            <% if user_signed_in? && current_user.own?(@post) %>
+            <% if user_signed_in? && current_user.own?(@post) && @post.publish?%>
               <span class="flex flex-col items-center rounded-xl bg-base-200 p-2 sm:p-3">
-                <%= link_to "https://twitter.com/intent/tweet?url=#{post_url(@post)}&text=#{CGI.escape("【#{@post.product.name}】のあまピタ評価をしたよ！")}\n&hashtags=#{CGI.escape("あまピタ")}",
+                <%= link_to "https://twitter.com/intent/tweet?text=#{CGI.escape("【#{@post.product.name}】のあまピタ評価をしたよ！\n\n#あまピタッ\n#{post_url(@post)}")}",
                     target: "_blank",
                     rel: "noopener noreferrer" do %>
                 <%= image_tag "x-logo.svg", class: "h-6 w-6" %>


### PR DESCRIPTION
## 概要
XシェアボタンとOGP画像生成機能の表示改善を行いました。
商品名の長さ制限とシェアURL構造の最適化しました。

---

### 📋 修正内容

#### Xシェア機能の改善
- シェアURL構造を改善（ハッシュタグ後にURLを配置）
- 公開済み投稿のみシェアボタンを表示するよう条件を追加
- URIエンコード方式を`URI.encode_www_form_component`に統一

#### OGP画像生成の最適化
- 商品名の文字数制限を40文字→24文字に変更
- OGP画像生成時のテキスト幅制限（`w_500`）を削除
- 長い商品名でも適切に表示されるよう調整

---

### 🔧その他微修正

- `CGI.escape`から`URI.encode_www_form_component`への変更でスペースエンコードを統一（`+` → `%20`）
- OGPタイトルを動的な商品名から固定値「甘さ評価」に変更

---

### ✅ 確認事項
- [x] 商品名24文字以内でOGP画像が適切に表示される
- [x] 公開済み投稿でのみTwitterシェアボタンが表示される
- [x] シェアURLのハッシュタグと改行が正しく動作する
- [x] 空白がある商品名でも + がOGPに反映されない

close #261