### PR TITLE
feat: OGP画像のキャッシュ対策機能を追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,6 +42,7 @@ module ApplicationHelper
     begin
       product_text = URI.encode_www_form_component("「#{post.product.name}」の").gsub("+", "%20")
       text_color = "6a6565"
+      cache_buster = post.updated_at.to_i
 
       image_configs = {
         lack_of_sweetness: "v1761662057/lack_of_sweetness_xgqer9.png",
@@ -55,9 +56,9 @@ module ApplicationHelper
       return asset_url("ogp.png") unless image_path
 
       "https://res.cloudinary.com/dbar0jd0k/image/upload/" \
-      "l_text:TakaoGothic_50_bold:#{product_text}," \
+      "l_text:TakaoGothic_40_bold:#{product_text}," \
       "co_rgb:#{text_color},c_fit,g_north,y_60/" \
-      "#{image_path}"
+      "#{image_path}?v=#{cache_buster}"
     rescue => e
       Rails.logger.error "OGP画像生成エラー: #{e.message}"
       asset_url("ogp.png")
@@ -66,7 +67,7 @@ module ApplicationHelper
 
   def post_meta_tags(post)
     ogp_image = generate_sweetness_ogp_url(post)
-    title = "甘さ評価"
+    title = "あまピタッ！"
     description = "甘すぎない、物足りなくない。あなたにぴったりの甘さが見つかるアプリ。"
 
     {

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -45,4 +45,13 @@ class Post < ApplicationRecord
 
     Time.current - product.created_at <= EDITABLE_HOURS.hours
   end
+
+  def share_url_with_cache_buster
+    Rails.application.routes.url_helpers.post_url(self, v: updated_at.to_i)
+  end
+
+  def x_share_text
+    return "" unless product&.name.present?
+      "【#{product.name}】のあまピタ判定をしたよ！\n\n#あまピタッ\n#{share_url_with_cache_buster}"
+  end
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -125,7 +125,7 @@
             </div>
             <% if user_signed_in? && current_user.own?(@post) && @post.publish?%>
               <span class="flex flex-col items-center rounded-xl bg-base-200 p-2 sm:p-3">
-                <%= link_to "https://twitter.com/intent/tweet?text=#{CGI.escape("【#{@post.product.name}】のあまピタ評価をしたよ！\n\n#あまピタッ\n#{post_url(@post)}")}",
+                <%= link_to "https://twitter.com/intent/tweet?text=#{CGI.escape(@post.x_share_text)}",
                     target: "_blank",
                     rel: "noopener noreferrer" do %>
                 <%= image_tag "x-logo.svg", class: "h-6 w-6" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,6 +31,7 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  Rails.application.routes.default_url_options = { protocol: "http", host: "localhost:3000" }
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :amazon
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,7 +93,7 @@ Rails.application.configure do
     authentication:       "plain",
     enable_starttls_auto: true
   }
-
+  Rails.application.routes.default_url_options = { protocol: "https", host: "amapita.com" }
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
-
+  Rails.application.routes.default_url_options = { protocol: "http", host: "localhost:3000" }
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 


### PR DESCRIPTION
## 概要

投稿編集後もX側で古いOGP画像がキャッシュされる問題を解決するため、OGP画像URLにキャッシュバスター機能を実装しました。

---

### 📋 修正内容

#### キャッシュバスター機能の実装
- `Post#share_url_with_cache_buster`メソッドを追加
  - 投稿の`updated_at`をクエリパラメータ`v`として付与
  - 投稿更新時に異なるURLを生成してキャッシュを回避
- cloudinary画像生成時もキャッシュバスター機能を使用

#### Xシェア機能の改善
- `Post#x_share_text`メソッドを追加
  - シェアテキストとキャッシュバスター付きURLを統合
  - ビューでの直接URL生成を廃止し、モデルに責務を移譲

#### URL生成設定の環境別対応
- 各環境でのURL生成設定を追加
  - Development: `http://localhost:3000`
  - Production: `https://amapita.com`
  - Test: `http://localhost:3000`

---

### 🔧その他微修正

#### OGP画像の調整
- フォントサイズを50→40に縮小（`TakaoGothic_50_bold` → `TakaoGothic_40_bold`）
- 可読性向上のため

#### OGPタイトルの変更
- 「甘さ評価」→「あまピタッ！」に変更
- アプリ名での統一によりブランディング強化

---

### ✅ 確認事項
- [x] 開発環境でキャッシュバスター付きURLが正しく生成される
- [x] 本番環境でHTTPS URLが正しく生成される
- [x] Xシェア時にキャッシュバスター付きURLが使用される
- [x] 投稿編集後に異なるクエリパラメータが生成される
- [x] OGP画像のフォントサイズが適切に調整されている
- [x] OGP情報が正しく取得される

close #266 