### PR TITLE
fix: Rails 7.2.3対応でvariant生成を修正

### DIFF
--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -1,16 +1,16 @@
 class PostDecorator < Draper::Decorator
   delegate_all
 
-  POST_VARIANT_OPTIONS = { resize_to_fill: [ 200, 200 ], format: :webp, saver: { quality: 75 } }.freeze
+  POST_VARIANT_OPTIONS = { resize_to_fill: [ 200, 200 ], format: :webp, quality: 75 }.freeze
 
   def post_image(**options)
     default_classes = "object-cover"
     custom_classes  = options[:class]
     merged_classes  = [ default_classes, custom_classes ].compact.join(" ")
 
-    image_source = if object.image.attached?
+    image_source = if object.image.attached? && object.image.blob.persisted?
       object.image.variant(POST_VARIANT_OPTIONS)
-    elsif object.product&.image&.attached?
+    elsif object.product&.image&.attached? && object.product.image.blob.persisted?
       object.product.image.variant(POST_VARIANT_OPTIONS)
     elsif object.product&.product_image_url.present?
       object.product.product_image_url

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -1,14 +1,14 @@
 class ProductDecorator < Draper::Decorator
   delegate_all
 
-  PRODUCT_VARIANT_OPTIONS = { resize_to_fill: [ 300, 300 ], format: :webp, saver: { quality: 75 } }.freeze
+  PRODUCT_VARIANT_OPTIONS = { resize_to_fill: [ 300, 300 ], format: :webp, quality: 75 }.freeze
 
   def product_image(**options)
     default_classes = "object-cover"
     custom_classes  = options[:class]
     merged_classes  = [ default_classes, custom_classes ].compact.join(" ")
 
-    image_source = if object.image.attached?
+    image_source = if object.image.attached? && object.image.blob.persisted?
       object.image.variant(PRODUCT_VARIANT_OPTIONS)
     elsif object.product_image_url.present?
       object.product_image_url

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,7 +1,7 @@
 class UserDecorator < Draper::Decorator
   delegate_all
 
-  AVATAR_VARIANT_OPTIONS = { resize_to_fill: [ 80, 80 ], format: :webp, saver: { quality: 65 } }.freeze
+  AVATAR_VARIANT_OPTIONS = { resize_to_fill: [ 80, 80 ], format: :webp, quality: 70 }.freeze
 
   def avatar_image(**options)
     default_classes = "rounded-full object-cover"


### PR DESCRIPTION
## 概要
#258 のRails 7.2.3バージョンアップデートに伴う画像variant生成の互換性修正

---

### 📋 修正内容
- **saverメソッド廃止対応**: `saver: { quality: xx }`から`quality: xx`に変更
- **安全性向上**: `blob.persisted?`チェックを追加し、未アップロード画像でのvariant生成エラーを防止
- **対象ファイル**:
  - `app/decorators/post_decorator.rb`
  - `app/decorators/product_decorator.rb` 
  - `app/decorators/user_decorator.rb`

---

### 🔧その他微修正
- UserDecoratorのアバター画像品質を65から70に調整

---

### ✅ 確認事項
- [x] 投稿画像のvariant生成が正常に動作する
- [x] 商品画像のvariant生成が正常に動作する
- [x] ユーザーアバター画像のvariant生成が正常に動作する
- [x] 各画像更新時にエラーが発生しない

close #278 