### PR TITLE
fix: 認証画面のモバイルUI改善

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,7 +1,7 @@
-<main class="container flex-1 pt-4 pb-14 sm:p-4 mx-auto flex items-center justify-center">
-  <div class="w-full max-w-lg bg-base-100 rounded-3xl px-4 md:px-15 md:py-2 mx-auto flex flex-col items-center">
+<main class="container flex-1 p-2 sm:p-4 mx-auto flex items-center justify-center">
+  <div class="w-full max-w-lg bg-base-100 rounded-3xl p-4 md:px-15 md:py-2 mx-auto flex flex-col items-center">
     <div class="mb-6 text-center">
-      <h2 class="text-xl md:text-2xl text-neutral font-bold pt-4"><%= t('.title') %></h2>
+      <h2 class="text-xl md:text-2xl text-neutral pt-4"><%= t('.title') %></h2>
     </div>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "w-full flex flex-col items-center" }) do |f| %>
@@ -10,13 +10,13 @@
       </div>
       <%= f.hidden_field :reset_password_token %>
       
-      <div class="w-65 sm:w-70">
+      <div class="w-70">
         <!-- 新しいパスワード -->
         <fieldset class="fieldset my-1" data-controller="password-visibility">
           <legend class="fieldset-legend pl-2">
-            <%= image_tag "lock-key.svg", class: "h-5 w-5" %>
-            <%= f.label :password, t('.new_password'), class: "text-base sm:text-sm" %>
-              <p class="label text-stone-400 text-xs pl-2"><%= t('defaults.password_format') %></p>
+            <%= image_tag "lock-key.svg", class: "size-5 sm:size-6" %>
+            <%= f.label :password, t('.new_password'), class: "text-base" %>
+              <p class="label text-stone-400 text-sm pl-2"><%= t('defaults.password_format') %></p>
           </legend>
 
           <%= f.password_field :password,
@@ -28,10 +28,10 @@
           <div class="flex items-center justify-between">
             <label class="label cursor-pointer gap-2 pl-1">
               <input type="checkbox"
-                    class="toggle toggle-xs border-stone-300/90 bg-stone-200 checked:border-stone-400 checked:bg-stone-300"
+                    class="toggle toggle-sm border-stone-300/90 bg-stone-200 checked:border-stone-400 checked:bg-stone-300"
                     data-password-visibility-target="checkbox"
                     data-action="password-visibility#update">
-              <span class="label-text text-xs text-stone-400"><%= t('defaults.password_visibility') %></span>
+              <span class="label-text text-sm text-stone-400"><%= t('defaults.password_visibility') %></span>
             </label>
           </div>
         </fieldset>
@@ -39,8 +39,8 @@
         <!-- パスワード確認 -->
         <fieldset class="fieldset my-1" data-controller="password-visibility">
           <legend class="fieldset-legend pl-2">
-            <%= image_tag "lock-key.svg", class: "h-5 w-5" %>
-            <%= f.label :password_confirmation, t('.password_confirmation'), class: "text-base sm:text-sm" %>
+            <%= image_tag "lock-key.svg", class: "size-5 sm:size-6" %>
+            <%= f.label :password_confirmation, t('.password_confirmation'), class: "text-base" %>
           </legend>
 
           <%= f.password_field :password_confirmation,
@@ -51,10 +51,10 @@
           <div class="flex items-center justify-between">
             <label class="label cursor-pointer gap-2 pl-1">
               <input type="checkbox"
-                    class="toggle toggle-xs border-stone-300/90 bg-stone-200 checked:border-stone-400 checked:bg-stone-300"
+                    class="toggle toggle-sm border-stone-300/90 bg-stone-200 checked:border-stone-400 checked:bg-stone-300"
                     data-password-visibility-target="checkbox"
                     data-action="password-visibility#update">
-              <span class="label-text text-xs text-stone-400"><%= t('defaults.password_visibility') %></span>
+              <span class="label-text text-sm text-stone-400"><%= t('defaults.password_visibility') %></span>
             </label>
           </div>
         </fieldset>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,7 +1,7 @@
 <main class="container flex-1 py-6 px-1 sm:p-4 mx-auto flex items-center justify-center">
   <div class="w-full max-w-lg bg-base-100 rounded-3xl px-4 sm:px-15 sm:py-6">
     <div class="mb-6 text-center">
-      <h2 class="text-xl md:text-2xl text-neutral font-bold pt-4"><%= t('.title') %></h2>
+      <h2 class="text-xl md:text-2xl text-neutral pt-4"><%= t('.title') %></h2>
     </div>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
@@ -9,7 +9,7 @@
 
         <div class="field py-5">
           <div class="flex items-center gap-1 pl-2 pb-1">
-            <%= image_tag "envelope.svg", class: "h-5 w-5" %>
+            <%= image_tag "envelope.svg", class: "size-5 sm:size-6" %>
             <%= f.label :email, class: "text-base" %>
           </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
-<main class="container flex-1 pt-4 pb-14 sm:p-4 mx-auto flex items-center justify-center">
+<main class="container flex-1 p-2 sm:p-4 mx-auto flex items-center justify-center">
   <div class="w-full max-w-lg bg-base-100 rounded-3xl p-4 md:px-15 md:py-2 mx-auto flex flex-col items-center">
-    <div class="flex flex-row items-center justify-center py-3 sm:py-6">
+    <div class="flex flex-row items-center justify-center py-4 sm:py-6">
       <h2 class="text-xl md:text-2xl text-neutral"><%= t('.title') %></h2>
     </div>
 
@@ -19,28 +19,28 @@
         <%= render "devise/shared/error_messages", resource: resource %>
       </div>
 
-      <div class="w-65 sm:w-70">
+      <div class="w-70">
         <fieldset class="fieldset my-1">
           <legend class="fieldset-legend pl-2">
-          <%= image_tag "user.svg", class: "h-5 w-5" %>
-            <%= f.label :name, class: "text-base sm:text-sm" %>
+          <%= image_tag "user.svg", class: "size-5 sm:size-6" %>
+            <%= f.label :name, class: "text-base" %>
           </legend>
           <%= f.text_field :name, placeholder: "表示名", class: "input focus:outline-none w-full" %>
         </fieldset>
 
         <fieldset class="fieldset my-1">
           <legend class="fieldset-legend pl-2">
-            <%= image_tag "envelope.svg", class: "h-5 w-5" %>
-            <%= f.label :email, class: "text-base sm:text-sm" %>
+            <%= image_tag "envelope.svg", class: "size-5 sm:size-6" %>
+            <%= f.label :email, class: "text-base" %>
           </legend>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: t('defaults.placeholders.sample_email'), class: "input focus:outline-none w-full" %>
         </fieldset>
 
-        <fieldset class="fieldset my-1" data-controller="password-visibility">
+        <fieldset class="fieldset my-2" data-controller="password-visibility">
           <legend class="fieldset-legend pl-2">
-            <%= image_tag "lock-key.svg", class: "h-5 w-5" %>
-            <%= f.label :password, class: "text-base sm:text-sm" %>
-            <p class="label text-stone-400 text-xs pl-2"><%= t('defaults.password_format') %></p>
+            <%= image_tag "lock-key.svg", class: "size-5 sm:size-6" %>
+            <%= f.label :password, class: "text-base" %>
+            <p class="label text-stone-400 text-sm pl-2"><%= t('defaults.password_format') %></p>
           </legend>
 
           <%= f.password_field :password, 
@@ -51,20 +51,20 @@
               } %>
           
           <div class="flex items-center justify-between">
-            <label class="label cursor-pointer gap-2 pl-1">
+            <label class="label cursor-pointer gap-1 pl-1">
               <input type="checkbox" 
-                    class="toggle toggle-xs border-stone-300/90 bg-stone-200 checked:border-stone-400 checked:bg-stone-300"
+                    class="toggle toggle-sm border-stone-300/90 bg-stone-200 checked:border-stone-400 checked:bg-stone-300"
                     data-password-visibility-target="checkbox"
                     data-action="password-visibility#update">
-              <span class="label-text text-xs text-stone-400">パスワードを表示</span>
+              <span class="label-text text-sm text-stone-400"><%= t('defaults.password_visibility') %></span>
             </label>
           </div>
         </fieldset>
 
-        <fieldset class="fieldset my-1" data-controller="password-visibility">
+        <fieldset class="fieldset my-2" data-controller="password-visibility">
           <legend class="fieldset-legend pl-2">
-            <%= image_tag "lock-key.svg", class: "h-5 w-5" %>
-            <%= f.label :password_confirmation, class: "text-base sm:text-sm" %>
+            <%= image_tag "lock-key.svg", class: "size-5 sm:size-6" %>
+            <%= f.label :password_confirmation, class: "text-base" %>
           </legend>
 
           <%= f.password_field :password_confirmation,
@@ -75,18 +75,18 @@
               } %>
           
           <div class="flex items-center justify-between">
-            <label class="label cursor-pointer gap-2 pl-1">
+            <label class="label cursor-pointer gap-1 pl-1">
               <input type="checkbox" 
-                    class="toggle toggle-xs border-stone-300/90 bg-stone-200 checked:border-stone-400 checked:bg-stone-300"
+                    class="toggle toggle-sm border-stone-300/90 bg-stone-200 checked:border-stone-400 checked:bg-stone-300"
                     data-password-visibility-target="checkbox"
                     data-action="password-visibility#update">
-              <span class="label-text text-xs text-stone-400"><%= t('defaults.password_confirmation_visibility') %></span>
+              <span class="label-text text-sm text-stone-400"><%= t('defaults.password_confirmation_visibility') %></span>
             </label>
           </div>
         </fieldset>
       </div>
 
-      <div class="form-control flex justify-center py-4">
+      <div class="form-control flex justify-center py-4 sm:py-6">
         <%= f.submit t('helpers.submit.register'), class: "bg-secondary button-primary" %>
       </div>
     <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
-<main class="container flex-1 pt-4 pb-14 sm:p-4 mx-auto flex items-center justify-center">
+<main class="container flex-1 p-2 sm:p-4 mx-auto flex items-center justify-center">
   <div class="w-full max-w-lg bg-base-100 rounded-3xl p-4 md:px-15 md:py-2 mx-auto flex flex-col items-center">
-    <div class="flex flex-row items-center justify-center py-3 sm:py-6">
+    <div class="flex flex-row items-center justify-center py-4 sm:py-6">
       <h2 class="text-xl md:text-2xl text-neutral"><%= t('.title') %></h2>
     </div>
 
@@ -19,11 +19,11 @@
         <%= render "devise/shared/error_messages", resource: resource %>
       </div>
 
-      <div class="w-65 sm:w-70">
+      <div class="w-70">
         <fieldset class="fieldset my-2">
           <legend class="fieldset-legend pl-2 pb-1">
-            <%= image_tag "envelope.svg", class: "h-5 w-5" %>
-            <%= f.label :email, class: "text-base sm:text-sm " %>
+            <%= image_tag "envelope.svg", class: "size-5 sm:size-6" %>
+            <%= f.label :email, class: "text-base" %>
           </legend>
 
           <%= f.email_field :email,
@@ -35,9 +35,9 @@
 
         <fieldset class="fieldset my-2" data-controller="password-visibility">
           <legend class="fieldset-legend pl-2 pb-1">
-            <%= image_tag "lock-key.svg", class: "h-5 w-5" %>
-            <%= f.label :password, class: "text-base sm:text-sm" %>
-            <p class="label text-stone-400 text-xs pl-2"><%= t('defaults.password_format') %></p>
+            <%= image_tag "lock-key.svg", class: "size-5 sm:size-6" %>
+            <%= f.label :password, class: "text-base" %>
+            <p class="label text-stone-400 text-sm pl-2"><%= t('defaults.password_format') %></p>
           </legend>
 
           <%= f.password_field :password,
@@ -50,10 +50,10 @@
           <div class="flex items-center justify-between">
             <label class="label cursor-pointer gap-2 py-1 pl-1">
               <input type="checkbox" 
-                    class="toggle toggle-xs border-stone-300/90 bg-stone-200 checked:border-stone-400 checked:bg-stone-300"
+                    class="toggle toggle-sm border-stone-300/90 bg-stone-200 checked:border-stone-400 checked:bg-stone-300"
                     data-password-visibility-target="checkbox"
                     data-action="password-visibility#update">
-              <span class="label-text text-xs text-stone-400"><%= t('defaults.password_visibility') %></span>
+              <span class="label-text text-sm text-stone-400"><%= t('defaults.password_visibility') %></span>
               
             </label>
           </div>
@@ -61,20 +61,20 @@
       </div>
 
       <% if devise_mapping.rememberable? %>
-        <div class="form-control pl-1 py-3">
+        <div class="form-control pl-1 py-2">
           <label class="inline-flex items-center">
-            <%= f.check_box :remember_me, class: "checkbox checkbox-xs checkbox-secondary mr-2" %>
+            <%= f.check_box :remember_me, class: "checkbox checkbox-sm checkbox-secondary mr-2" %>
             <%= f.label :remember_me, class: "text-sm" %>
           </label>
         </div>
       <% end %>
 
-      <div class="form-control flex justify-center pt-2">
+      <div class="form-control flex justify-center pt-5">
         <%= f.submit t('.login'), class: "bg-accent button-primary" %>
       </div>
     <% end %>
 
-    <div class="flex flex-col items-center p-8 gap-5 text-sm">
+    <div class="flex flex-col items-center py-9 gap-6 text-sm">
       <div class="flex justify-center text-neutral">
         <%= link_to new_user_registration_path, class: "underline-offset-4 hover:underline transition-all" do %>
           <%= t('.to_register_page') %>


### PR DESCRIPTION
## 概要
認証画面のレスポンシブ対応とUI調整を行いました。モバイルとデスクトップでの視認性を向上させ、より使いやすいインターフェースにしました。

---

### 📋 修正内容

#### 1. トグルボタンのサイズ調整
- `toggle-xs` → `toggle-sm` に変更
- モバイルでもタップしやすいサイズに改善
- 全ての認証画面（新規登録・ログイン・パスワードリセット）に適用

#### 2. アイコンのレスポンシブ対応
- `h-5 w-5` → `size-5 sm:size-6` に変更
- スマホでは20px、それ以上の画面では24pxで表示
- 視認性の向上とバランスの改善

#### 3. フォント・文字サイズの調整
- ラベルテキスト: `text-base sm:text-sm` → `text-base` に統一
- パスワード表示トグルのラベル: `text-xs` → `text-sm` に変更
- 注記テキスト: `text-xs` → `text-sm` に変更
- 全体的な可読性の向上

#### 4. レイアウトの微調整
- フィールドコンテナ: `w-65 sm:w-70` → `w-70` に統一
- チェックボックス: `checkbox-xs` → `checkbox-sm` に変更
- パディング調整でより快適な視覚的間隔を実現

---

### 🔧その他微修正

#### テキストの統一化
- 新規登録画面のパスワード確認欄のトグルラベルをi18n対応に変更
  - ハードコード `"パスワードを表示"` → `t('defaults.password_visibility')` に修正

---

### ✅ 確認事項
- [x] 変更分が反映されていること

close #291 