### PR TITLE
fix: 本番環境でいいねボタンが正しく更新されない問題を修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,7 +114,11 @@ class User < ApplicationRecord
   end
 
   def like(post)
+    return if like?(post)
     like_posts << post
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error("Like creation failed for user:#{id}, post:#{post.id} - #{e.message}")
+    false
   end
 
   def liked(post)
@@ -122,6 +126,7 @@ class User < ApplicationRecord
   end
 
   def like?(post)
-    like_posts.include?(post)
+    # キャッシュを避ける
+    likes.exists?(post_id: post.id)
   end
 end

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,19 +1,3 @@
-<%= turbo_stream.replace "like-button-mobile-#{@post.id}" do %>
-  <%= render 'posts/like_buttons', post: @post, button_id: "like-button-mobile-#{@post.id}" %>
-<% end %>
-
-<%= turbo_stream.replace "like-button-pc-#{@post.id}" do %>
-  <%= render 'posts/like_buttons', post: @post, button_id: "like-button-pc-#{@post.id}" %>
-<% end %>
-
-<%= turbo_stream.replace "like-button-product-page-#{@post.id}" do %>
-  <%= render 'posts/like_buttons', post: @post, button_id: "like-button-product-page-#{@post.id}" %>
-<% end %>
-
-<%= turbo_stream.replace "like-button-partial-page-#{@post.id}" do %>
-  <%= render 'posts/like_buttons', post: @post, button_id: "like-button-partial-page-#{@post.id}" %>
-<% end %>
-
-<%= turbo_stream.replace "like-button-mypage-#{@post.id}" do %>
-  <%= render 'posts/like_buttons', post: @post, button_id: "like-button-mypage-#{@post.id}" %>
+<%= turbo_stream.replace "like-button-#{@post.id}" do %>
+  <%= render 'posts/like_buttons', post: @post, button_id: "like-button-#{@post.id}" %>
 <% end %>

--- a/app/views/likes/destroy.turbo_stream.erb
+++ b/app/views/likes/destroy.turbo_stream.erb
@@ -1,19 +1,3 @@
-<%= turbo_stream.replace "like-button-mobile-#{@post.id}" do %>
-  <%= render 'posts/like_buttons', post: @post, button_id: "like-button-mobile-#{@post.id}" %>
-<% end %>
-
-<%= turbo_stream.replace "like-button-pc-#{@post.id}" do %>
-  <%= render 'posts/like_buttons', post: @post, button_id: "like-button-pc-#{@post.id}" %>
-<% end %>
-
-<%= turbo_stream.replace "like-button-product-page-#{@post.id}" do %>
-  <%= render 'posts/like_buttons', post: @post, button_id: "like-button-product-page-#{@post.id}" %>
-<% end %>
-
-<%= turbo_stream.replace "like-button-partial-page-#{@post.id}" do %>
-  <%= render 'posts/like_buttons', post: @post, button_id: "like-button-partial-page-#{@post.id}" %>
-<% end %>
-
-<%= turbo_stream.replace "like-button-mypage-#{@post.id}" do %>
-  <%= render 'posts/like_buttons', post: @post, button_id: "like-button-mypage-#{@post.id}" %>
+<%= turbo_stream.replace "like-button-#{@post.id}" do %>
+  <%= render 'posts/like_buttons', post: @post, button_id: "like-button-#{@post.id}" %>
 <% end %>

--- a/app/views/posts/_like_buttons.html.erb
+++ b/app/views/posts/_like_buttons.html.erb
@@ -1,10 +1,10 @@
 <%# 一意のID生成(呼び出し元で指定可能にする) %>
 <% button_id = local_assigns[:button_id] || "like-button-#{post.id}" %>
 
-<div id="<%= button_id %>">
+<%= turbo_frame_tag button_id do %>
   <% if current_user.like?(post) %>
     <%= render 'posts/liked', post: post, button_id: button_id %>
   <% else %>
     <%= render 'posts/like', post: post, button_id: button_id %>
   <% end %>
-</div>
+<% end %>

--- a/app/views/posts/_liked_posts.html.erb
+++ b/app/views/posts/_liked_posts.html.erb
@@ -56,7 +56,7 @@
             <span class="flex items-center gap-1">
             <% unless post.unpublish? || current_user&.own?(post) %>
                 <% if user_signed_in? %>
-                <%= render 'posts/like_buttons', { post: post, button_id: "like-button-mypage-#{post.id}" } %>
+                <%= render 'posts/like_buttons', { post: post, button_id: "like-button-#{post.id}" } %>
                 <% else %>
                 <label class="flex flex-row items-center gap-1 cursor-pointer tooltip tooltip-left sm:tooltip-bottom" 
                         data-tip="<%= t('defaults.require_login') %>">

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -28,14 +28,14 @@
       <% end %>
     </div>
 
-    <div class="absolute top-3 sm:top-4 right-2 sm:right-4">
+    <div class="absolute top-5 sm:top-6 right-5 sm:right-6">
       <span class="flex items-center gap-1">
         <% unless post.publish? %>
-          <%= image_tag "lock-key.svg", class: "size-5 sm:size-7" %>
+          <%= image_tag "lock-key.svg", class: "size-6 sm:size-7" %>
         <% end %>
-        <% unless post.unpublish? || current_user&.own?(post) %>
+        <% if post.publish? && !current_user&.own?(post) %>
           <% if user_signed_in? %>
-            <%= render 'posts/like_buttons', { post: post, button_id: "like-button-partial-page-#{post.id}" } %>
+            <%= render 'posts/like_buttons', { post: post, button_id: "like-button-#{post.id}" } %>
           <% else %>
             <label class="flex flex-row items-center gap-1 cursor-pointer tooltip tooltip-left sm:tooltip-bottom" 
                   data-tip="<%= t('defaults.require_login') %>">
@@ -45,7 +45,7 @@
         <% end %>
         <!-- 編集・削除ボタン -->
         <% if user_signed_in? && current_user.own?(post) %>
-          <div class="dropdown dropdown-bottom dropdown-end z-10">
+          <div class="dropdown dropdown-top dropdown-end z-10">
             <div tabindex="0" role="button" class="btn btn-lg btn-square btn-ghost hover:bg-stone-300">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none"
                    viewBox="0 0 24 24" class="inline-block h-7 w-7 text-base-300 stroke-current">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -20,14 +20,14 @@
                 x-init="imageLoaded = $el.querySelector('img')?.complete || false">
           <div x-cloak x-show="!imageLoaded" class="flex animate-pulse space-x-4">
             <div class="p-4">
-              <div class="size-30 sm:size-35 rounded-xl bg-stone-300"></div>
+              <div class="size-25 sm:size-35 rounded-xl bg-stone-300"></div>
             </div>
           </div>
 
           <div x-show="imageLoaded" x-transition>
             <div class="p-4">
               <%= @post.decorate.post_image(
-                    class: "size-30 sm:size-35",
+                    class: "size-25 sm:size-35",
                     "@load" => "imageLoaded = true",
                     "@error"=> "imageLoaded = true"
                   ) %>
@@ -55,6 +55,7 @@
               <%= @post.product.manufacturer %>
             </div>
           </div>
+
           <!-- lg未満：リンク付き -->
           <div class="block lg:hidden text-lg px-1 sm:px-0 max-w-xs text-center sm:text-left mx-auto sm:mx-0 underline decoration-offset-4">
             <%= link_to product_path(@post.product) do %>
@@ -92,91 +93,61 @@
           <% end %>
 
           <!-- 編集・削除＆ブックマーク -->
-          <% if user_signed_in? %>
-            <div class="absolute top-2 right-2 sm:right-24 z-10 flex items-center sm:gap-2">
-
+          <div class="absolute top-2 right-2 sm:right-24 z-10 flex items-center gap-3 sm:gap-4">
+            <!-- いいね -->
+            <% unless @post.unpublish? || current_user&.own?(@post) %>
               <div class="flex-shrink-0">
-                <%= render 'products/bookmark_buttons', { product: @post.product } %>
-              </div>
-
-              <% if current_user.own?(@post) %>
-                <!-- 編集・削除 -->
-                <div class="dropdown dropdown-bottom dropdown-end">
-                  <div tabindex="0" role="button" class="btn btn-lg btn-square btn-ghost hover:bg-stone-300">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none"
-                        viewBox="0 0 24 24" class="inline-block h-7 w-7 text-base-300 stroke-current">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                            d="M5 12h.01M12 12h.01M19 12h.01
-                              M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z"></path>
-                    </svg>
+                <% if user_signed_in? %>
+                  <%= render 'posts/like_buttons', { post: @post, button_id: "like-button-#{@post.id}" } %>
+                <% else %>
+                  <div class="cursor-pointer tooltip tooltip-top z-10" 
+                      data-tip="<%= t('defaults.require_login') %>"
+                      onclick="location.href='<%= new_user_session_path %>'">
+                    <%= image_tag "heart.svg", class: "size-6 ml-1" %>
                   </div>
+                <% end %>
+              </div>
+            <% end %>
 
-                  <ul tabindex="0" class="dropdown-content menu bg-white rounded-box w-25 p-2 shadow-sm text-xs lg:text-sm flex flex-col text-center gap-2">
-                    <li>
-                      <%= link_to edit_post_path(@post), data: { turbo: false } do %>
-                        <%= t('helpers.submit.edit') %>
-                      <% end %>
-                    </li>
-                    <li>
-                      <%= link_to post_path(@post), class: "text-error",
-                            data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
-                        <%= t('helpers.submit.delete') %>
-                      <% end %>
-                    </li>
-                  </ul>
+            <!-- ブックマーク -->
+            <div class="flex-shrink-0">
+              <% if user_signed_in? %>
+                <%= render 'products/bookmark_buttons', { product: @post.product } %>
+              <% else %>
+                <div class="cursor-pointer tooltip tooltip-top" 
+                    data-tip="<%= t('defaults.require_login') %>"
+                    onclick="location.href='<%= new_user_session_path %>'">
+                  <%= image_tag "bookmark.svg", class: "size-6 ml-1" %>
                 </div>
               <% end %>
-
             </div>
-          <% end %>
-        </div>
-      </div>
-    </div>
 
-    <!-- 評価部分（lg未満） -->
-    <div class="lg:hidden flex justify-center w-full py-2">
-      <div class="flex flex-col text-center items-start text-sm pb-2 text-neutral">
-        <p class="pb-1"><%= t('.rating') %></p>
-        <!-- あまピタ度・シェア・いいね -->
-        <div class="flex-shrink-0">
-          <% rating_images = {
-              "lack_of_sweetness" => "smiley-meh.svg",
-              "could_be_sweeter" => "smiley-blank.svg",
-              "perfect_sweetness" => "smiley-wink.svg",
-              "slightly_too_sweet" => "smiley-nervous.svg",
-              "too_sweet" => "smiley-x-eyes.svg"
-          } %>
+            <!-- 編集・削除 -->
+            <% if user_signed_in? && current_user.own?(@post) %>
+              <div class="dropdown dropdown-bottom dropdown-end pb-10">
+                <div tabindex="0" role="button" class="btn btn-lg btn-square btn-ghost hover:bg-stone-300">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none"
+                      viewBox="0 0 24 24" class="inline-block h-7 w-7 text-base-300 stroke-current">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M5 12h.01M12 12h.01M19 12h.01
+                            M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z"></path>
+                  </svg>
+                </div>
 
-          <% bg_colors = {
-              "lack_of_sweetness" => "bg-accent",
-              "could_be_sweeter" => "bg-accent",
-              "perfect_sweetness" => "bg-primary",
-              "slightly_too_sweet" => "bg-secondary",
-              "too_sweet" => "bg-secondary"
-          } %>
-          <div class="flex flex-row items-center justify-center gap-2 flex-wrap">
-            <div class="inline-flex items-center rounded-2xl gap-2 py-2  px-4 text-neutral text-base <%= bg_colors[@post.sweetness_rating] %>">
-              <%= image_tag rating_images[@post.sweetness_rating], class: "h-8 w-8" %>
-              <p><%= I18n.t("enums.post.sweetness_rating.#{@post.sweetness_rating}") %></p>
-            </div>
-            <% if user_signed_in? && current_user.own?(@post) && @post.publish? %>
-              <%= link_to "https://twitter.com/intent/tweet?text=#{CGI.escape(@post.x_share_text)}",
-                    target: "_blank",
-                    rel: "noopener noreferrer" do %>
-                <span class="flex flex-col items-center rounded-xl bg-base-200 p-2 sm:p-3">
-                  <%= image_tag "x-logo.svg", class: "size-6" %>
-                </span>
-              <% end %>
-            <% end %>
-            <% unless @post.unpublish? || current_user&.own?(@post) %>
-              <% if user_signed_in? %>
-                <%= render 'posts/like_buttons', { post: @post, button_id: "like-button-mobile-#{@post.id}" } %>
-              <% else %>
-                <label class="cursor-pointer tooltip tooltip-top" 
-                      data-tip="<%= t('defaults.require_login') %>">
-                  <%= image_tag "heart.svg", class: "size-6 ml-1" %>
-                </label>
-              <% end %>
+                <ul tabindex="0" class="dropdown-content menu bg-white rounded-box w-25 p-2 shadow-sm text-xs lg:text-sm flex flex-col text-center gap-2">
+                  <li>
+                    <%= link_to edit_post_path(@post), data: { turbo: false } do %>
+                      <%= t('helpers.submit.edit') %>
+                    <% end %>
+                  </li>
+                  <li>
+                    <%= link_to post_path(@post), class: "text-error",
+                          data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+                      <%= t('helpers.submit.delete') %>
+                    <% end %>
+                  </li>
+                </ul>
+              </div>
             <% end %>
           </div>
         </div>
@@ -241,16 +212,6 @@
                   <span class="flex flex-col items-center rounded-xl bg-base-200 p-2 sm:p-3">
                     <%= image_tag "x-logo.svg", class: "size-6" %>
                 </span>
-                <% end %>
-              <% end %>
-              <% unless @post.unpublish? || current_user&.own?(@post) %>
-                <% if user_signed_in? %>
-                  <%= render 'like_buttons', { post: @post, button_id: "like-button-pc-#{@post.id}" } %>
-                <% else %>
-                  <div class="cursor-pointer tooltip tooltip-top z-10" 
-                      data-tip="<%= t('defaults.require_login') %>">
-                  <%= image_tag "heart.svg", class: "size-6 ml-1" %>
-                  </div>
                 <% end %>
               <% end %>
             </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -19,13 +19,13 @@
               x-init="imageLoaded = $el.querySelector('img')?.complete || false">
         <div x-cloak x-show="!imageLoaded" class="flex animate-pulse space-x-4">
           <div class="pt-6 px-4 sm:p-4">
-            <div class="size-30 sm:size-35 rounded-xl bg-stone-300"></div>
+            <div class="size-25 sm:size-35 rounded-xl bg-stone-300"></div>
           </div>
         </div>
         <div x-show="imageLoaded" x-transition>
           <div class="pt-6 px-4 sm:p-4">
             <%= @product.decorate.product_image(
-                  class: "size-30 sm:size-35 object-contain",
+                  class: "size-25 sm:size-35 object-contain",
                   "@load" => "imageLoaded = true",
                   "@error"=> "imageLoaded = true"
                 ) %>
@@ -44,14 +44,14 @@
       <% end %>
     </div>
 
-    <div class="flex flex-col justify-start items-center sm:items-start text-neutral py-4 md:px-0">
+    <div class="relative flex flex-col justify-start items-center sm:items-start text-neutral py-4 md:px-0">
       <div class="flex flex-col items-center sm:items-start w-full">
         <div class="flex items-center pl-1 justify-between w-full">
           <div class="text-xs sm:text-sm text-base-300 max-w-sm pb-1">
             <%= @product.manufacturer %>
           </div>
           <% if user_signed_in? %>
-            <div class="flex-shrink-0">
+            <div class="absolute top-2 right-1 sm:right-0">
               <%= render 'bookmark_buttons', { product: @product } %>
             </div>
           <% end %>
@@ -180,14 +180,14 @@
 
               <div class="flex flex-row gap-1 items-start">
                 <!-- ユーザー情報 -->
-                <div class="flex flex-col items-center p-1 w-24 sm:w-28 shrink-0 gap-1">
+                <div class="flex flex-col items-center p-1 w-24 shrink-0 gap-1">
                   <%= post.user.decorate.avatar_image(class: "w-10 h-10") %>
                   <span class="mt-1 text-xs text-start line-clamp-3 sm:line-clamp-2 mx-1"><%= post.user.name %></span>
                 </div>
 
                 <!-- 編集・削除・いいねボタン -->
                 <% if user_signed_in? && current_user.own?(post) %>
-                  <div class="dropdown dropdown-left dropdown-top absolute top-3 sm:top-4 right-0 sm:right-1 pt-2 z-10">
+                  <div class="dropdown dropdown-left dropdown-top absolute top-3 sm:top-4 right-0 sm:right-2 pt-2 z-10">
                     <div tabindex="0" role="button" class="rounded-xl bg-stone-100 ring-2 ring-base-200 duration-200 hover:brightness-96 p-1 sm:p-2">
                       <%= image_tag "pencil.svg", class: "size-5 flex-shrink-0" %>
                     </div>
@@ -207,8 +207,8 @@
                     </ul>
                   </div>
                 <% elsif user_signed_in? && !post.unpublish?  %>
-                  <div class="absolute top-6 right-0 sm:right-2 z-10">
-                    <%= render 'posts/like_buttons', { post: post, button_id: "like-button-product-page-#{post.id}" } %>
+                  <div class="absolute top-6 right-2 z-10">
+                    <%= render 'posts/like_buttons', { post: post, button_id: "like-button-#{post.id}" } %>
                   </div>
                 <% end %>
 
@@ -231,9 +231,9 @@
                     } %>
 
                   <!-- 甘さ評価 -->
-                  <div class="flex items-center justify-start rounded-xl gap-1 sm:gap-2 px-1 sm:px-4 py-2.5
+                  <div class="flex items-center justify-start rounded-xl gap-1 sm:gap-2 px-2 sm:px-4 py-2.5
                               text-neutral text-sm w-fit <%= bg_colors[post.sweetness_rating] %>">
-                    <%= image_tag rating_images[post.sweetness_rating], class: "h-5 w-5 sm:h-7 sm:w-7 flex-shrink-0" %>
+                    <%= image_tag rating_images[post.sweetness_rating], class: "h-6 w-6 sm:h-7 sm:w-7 flex-shrink-0" %>
                     <p class="truncate"><%= I18n.t("enums.post.sweetness_rating.#{post.sweetness_rating}") %></p>
                   </div>
 


### PR DESCRIPTION
## 概要
本番環境でいいねボタンが正しく更新されない問題を修正

本番環境において、投稿一覧・投稿詳細・マイページでいいねボタンを押した際、DBには正常に保存されるものの、画面上の表示が更新されない（リロードすると反映される）問題が発生していました。

**原因**:
- button_idが画面ごとに異なり（`like-button-mobile-`, `like-button-pc-`, `like-button-partial-page-`など）、Turbo Streamの更新対象とページ内の実際のIDが不一致
- 投稿詳細ページで同じID `like-button-#{@post.id}` のTurbo Frameが2つ存在（モバイル用とPC用）
- 重複いいね時のエラーハンドリングが不足

**対応**:
- すべてのページでbutton_idを `like-button-#{post.id}` に統一
- 投稿詳細ページのいいねボタンを1箇所（ユーザー情報エリアの右上）に配置
- 重複いいね防止ロジックとエラーハンドリングを追加
- `User#like?` メソッドを `exists?` を使用する実装に変更（キャッシュ問題の回避）

---

### 📋 修正内容

#### 1. Userモデル（`app/models/user.rb`）
- `like` メソッドに重複チェックとエラーハンドリングを追加
- `like?` メソッドを `likes.exists?(post_id: post.id)` に変更（キャッシュを避ける）

#### 2. Turbo Stream（`app/views/likes/create.turbo_stream.erb`, `destroy.turbo_stream.erb`）
- 複数のbutton_IDを更新する実装から、単一のID `like-button-#{@post.id}` のみを更新する実装に変更

#### 3. いいねボタンパーシャル（`app/views/posts/_like_buttons.html.erb`）
- `turbo_frame_tag` を追加してフレームを一意に管理

#### 4. 投稿詳細ページ（`app/views/posts/show.html.erb`）
- lg未満とlg以上の2箇所に配置していたいいねボタンを削除
- ユーザー情報エリアの右上（ブックマークボタンの隣）に統一配置
- 未ログイン時の表示も対応

#### 5. その他のビュー
- 投稿一覧（`app/views/posts/_post.html.erb`）
- マイページ（`app/views/posts/_liked_posts.html.erb`）
- 商品詳細（`app/views/products/show.html.erb`）
- すべてのbutton_idを `like-button-#{post.id}` に統一
---

### ✅ 確認事項
- [x] 開発環境で各画面（投稿一覧、投稿詳細、マイページ、商品詳細）でいいねボタンの動作確認
- [x] いいね追加・削除が即座に反映されることを確認
- [x] ページ遷移後も状態が保持されることを確認
- [x] 重複いいねが防止されることをRailsコンソールで確認
- [x] ログにエラーが出ていないことを確認
- [x] 本番環境デプロイ後の動作確認

close #303 