### PR TITLE
feat:「その他」選択時の検索機能を拡張

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -12,6 +12,18 @@ class Product < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
 
+  def self.full_manufacturer_list
+    @full_manufacturer_list ||= I18n.t("products.manufacturers.list")
+  end
+
+  def self.main_manufacturers
+    @main_manufacturers ||= full_manufacturer_list - [ "その他" ]
+  end
+
+  scope :manufacturer_other, -> {
+    where.not(manufacturer: main_manufacturers)
+  }
+
   def total_posts
     posts.publish.size
   end


### PR DESCRIPTION
## 概要
プルダウンで「その他」を選択した際に、「その他」の他に主要メーカー以外の商品も検索対象とする機能を実装しました。

---

### 📋 修正内容
- `apply_other_manufacturer_filter`メソッドを追加し、「その他」選択時の検索ロジックを拡張
- `Product`モデルに`manufacturer_other`スコープを追加
- I18n定数を必要なタイミングのみでi18nの翻訳を取得することで、アプリ起動時のI18n読み込み失敗を対策
- `@main_manufacturers ||= [...] ` でメモ化することで、2回目以降の「その他」検索時に保存された値をそのまま使用し、パフォーマンスを最適化

---

### 🔧その他微修正
- 新着投稿とおすすめ投稿の両方で「その他」フィルター機能を適用

---

### ✅ 確認事項
- [x] プルダウンで「その他」を選択すると主要メーカー以外の商品が表示される
- [x] 新着投稿一覧で「その他」検索が正常に動作する
- [x] おすすめ投稿一覧で「その他」検索が正常に動作する
- [ ] 既存の検索機能に影響がない -> #308 にて対応

close #306 