### PR TITLE
improve: ユーザー名の重複を許可

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
 
   has_one_attached :avatar
 
-  validates :name, presence: true, length: { maximum: 20 }, uniqueness: true
+  validates :name, presence: true, length: { maximum: 20 }
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP },
             uniqueness: { case_sensitive: false }
   validates :uid, presence: true, uniqueness: { scope: :provider }


### PR DESCRIPTION
## 概要

Google認証時にユーザー名が重複している場合の登録エラーをログで確認したため、Userモデルのnameフィールドから一意性制約を削除しました。

---

### 📋 修正内容
- Userモデルの`name`フィールドから`uniqueness: true`を削除
- ユーザー名の重複を許可し、Google OAuth認証での登録体験を改善
- 一意性が必要な項目（email、uid + provider）は引き続き制約を維持

**修正ファイル:**
- `app/models/user.rb`

### ✅ 確認事項
- [ ] 重複したユーザー名でも登録できること
- [ ] Google認証での新規ユーザー登録が正常に動作すること
- [ ] 既存のバリデーション（presence、length）は正常に動作すること  
- [ ] メールアドレスとUID+Providerの一意性制約は維持されていること

close #327 